### PR TITLE
Draft14

### DIFF
--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -372,7 +372,7 @@ device.
 The A8B8G8R8*PACK32 formats are prohibited because the end result
 is the same regardless of whether the data is treated as packed
 into 32-bits or as the equivalent R8G8B8A8 format, i.e. as an array
-of 4 bytes, and a Data Format Descriptor cannot distinguish between
+of 4 bytes, so a Data Format Descriptor cannot distinguish between
 these cases.
 
 The \*SCALED* formats are prohibited because they are intended for
@@ -437,7 +437,7 @@ are defined as in <<VULKAN11EXT>>.
 `typeSize` specifies the size of the data type in bytes used to
 upload the data to a graphics API. When `typeSize` is greater than
 1, software on big-endian systems must endian convert all image
-data since it is little-endian. When format is `VK_UNKNOWN`,
+data since it is little-endian. When format is `VK_FORMAT_UNDEFINED`,
 `typeSize` must equal 1. For formats whose Vulkan names have the
 suffix `_BLOCK` it must equal 1. For formats with the suffix `_PACKxx`
 it must equal the value of stem:[xx / 8]. For unpacked formats,
@@ -553,9 +553,9 @@ of `0` indicates no supercompression.
 
 The supercompression scheme is applied independently to each mip
 level to permit streaming and random access to the levels. The
-format of the data in `<<levelImages>>` for a scheme is specified
-in the reference given in the _Level Data Format_ column of
-<<supercompressionSchemes>>.
+format of the data in `<<_levelimages,levelImages>>` for a scheme
+is specified in the reference given in the _Level Data Format_
+column of <<supercompressionSchemes>>.
 
 Schemes that require data global to all levels can store it as
 described in `<<supercompressionGlobalData>>`. Currently only Basis
@@ -575,13 +575,12 @@ LZW-style lossless supercompression, e.g, schemes 2 and 3, is
 generally ineffective on the block-compressed data of GPU texture
 formats. It is best reserved for use with uncompressed texture
 formats or with block-compressed data that has been specially
-optimized for LZW-style supercompression, such as by _Rate Distortion
-Optimization_ mode <<RDO>>.
+optimized such as by _Rate Distortion Optimization_ mode <<RDO>>.
 
 Basis Universal internally uses some block-compressed texture formats
 and includes rate distortion optimization. Normally encoding to the
-internal format is combined with supercompression. So consider it as
-being applicable only to uncompressed images.
+internal format is combined with supercompression. Therefore it is
+applicable only to uncompressed images.
 ====
 
 ==== Scheme Notes (Normative)
@@ -592,13 +591,18 @@ being applicable only to uncompressed images.
   which color and alpha components are present.
   See <<DFD for Basis Universal>>.
 
+* `<<_levelsp_uncompressedbytelength,levels[p].uncompressedByteLength>>`
+  must be 0.
+
 [NOTE]
 .Rationale
 ====
-The Basis Universal encoder combines encoding to ETC1S with deflation.
-The transcoder combines inflation to ETC1S with transcoding to one
-of many possible block compressed formats. There is therefore no
-common pre- and post-supercompression format.
+The Basis Universal encoder combines encoding to a block-compressed
+format, chosen for ease of transcoding, with deflation. The transcoder
+combines inflation back to the internal block-compressed format
+with transcoding to one of many possible other block compressed
+formats. There is therefore no common pre- and post-supercompression
+format.
 ====
 
 ===== ZLIB
@@ -666,8 +670,10 @@ value must be 0 when `sgdByteLength` = 0.
 
 ==== sgdByteLength
 The number of bytes of
-`<<_supercompressionglobaldata,supercompressionGlobalData>>`.  It
-schemes the value is 0.
+`<<_supercompressionglobaldata,supercompressionGlobalData>>`. For
+supercompression schemes for which no reference is provided in the
+_Global Data Format_ column of <<supercompressionSchemes>>.  the
+value must be 0.
 
 ==== Level Index
 An array, `levels`, giving the offset from the start of the file and
@@ -700,7 +706,8 @@ and all pixels (or blocks) in each row for the mipmap level. It
 does not include any bytes in `<<_mippadding,mipPadding>>`.  When
 `supercompressionScheme == 0`,
 `<<_levelsp_bytelength,levels[p].byteLength>>` must have
-the same value as this.
+the same value as this.   When `supercompressionScheme == 1`, Basis
+Universal, the value must be 0.
 
 The value of a level's `uncompressedByteLength` must satisfy the
 following condition:
@@ -750,7 +757,9 @@ _dfDescriptorBlock_.
   never contradict the DFD and, vice-versa, the DFD must not contradict
   `<<_vkformat,vkFormat>>`. Supercompression schemes > 1 are an
   exception to this rule. In those cases the DFD will not be that for
-  the `<<_vkformat,vkFormat>>` value.
+  the `<<_vkformat,vkFormat>>` value. To avoid any doubt,
+  `VK_FORMAT_UNDEFINED` cannot contradict a DFD.
+  DFD.
 * `colorModel` must be `KHR_DF_MODEL_RGBSDA`, `KHR_DF_MODEL_YUVSDA`
   or one of the block compressed color models listed in <<KDF13>> Section
   5.6 or its successors, currently `KDF_DF_MODEL_BC1A` to
@@ -795,14 +804,16 @@ Premultiplied Alpha::
 
 ===== DFD for Basis Universal
 When `<<_supercompressionscheme,supercompressionScheme>> is 1` the
-_dfDescriptorBlock_ must retain the `transferFunction`, `colorPrimaries`,
-and `flags` of the pre-deflation image data. It must also indicate
-which components are present in the deflated data by using color
-model `KHR_DF_MODEL_RGBSDA`, 0 length `bytesPlane[0-7]` and zero length
-and size samples for the present components. See <<KDF13>> Section
-5.19 "Unsized Formats" for details of this usage.
-<<example_rg>> gives an example DFD for images that had 2 components prior to
-deflation.
+_dfDescriptorBlock_ must retain the `colorModel`, `transferFunction`,
+`colorPrimaries`, and `flags` of the pre-Basis Universal-encoding
+image data. It must also indicate which components are present in
+the deflated data.  Thus the DFD will be that of the pre-Basis
+Universal-encoding data with `bytesPlane[0-7]` set to 0 and all
+samples having zero length and offsets to indicate an _unsized
+format_ as described in Section 5.19 "Unsized Formats" of <<KDF13>>.
+`sampleLower` and `sampleUpper` should also be 0. <<example_rg>>
+gives an example DFD for images that had 2 unsigned components prior
+to Basis Universal encoding.
 
 [[example_rg]]
 .Example RG descriptor
@@ -912,7 +923,7 @@ The number of bytes of combined key and value data in one key/value
 pair. This includes the size of the key, the required NUL byte
 terminating the key, and all the bytes of data in the value. If the
 value is a UTF-8 string it should be NUL terminated and
-`keyAndValueByteLength` should include the NUL character (but code
+`keyAndValueByteLength` must include the NUL character (but code
 that reads KTX files must not assume that value fields are NUL
 terminated). `keyAndValueByteLength` does not include the bytes in
 `<<_valuepadding,valuePadding>>`.
@@ -931,13 +942,13 @@ character that terminates the key is the Value data.
 
 The Value data may consist of any arbitrary data bytes. Any byte
 value is allowed. It is encouraged that the value be a NUL terminated
-UTF-8 string without a BOM, but this is not required. If the Value data
-is binary, it is a sequence of bytes rather than of words. It is up to
-the vendor defining the key to specify how those bytes are to be
-interpreted (including the endianness of any encoded numbers). If
-the Value data is a string of bytes then the NUL termination should
-be included in the `keyAndValueByteLength` byte count (but programs
-that read KTX files must not rely on this).
+UTF-8 string without a BOM, but this is not required. If the Value
+data is binary, it is a sequence of bytes rather than of words. It
+is up to the vendor defining the key to specify how those bytes are
+to be interpreted. If any bytes encode multi-byte numbers they must
+be in little-endian order. If the Value data is a string then the
+NUL termination, if present, must be included in `keyAndValueByteLength`
+(but programs that read KTX files must not rely on NUL termination).
 
 ==== valuePadding
 Contains between 0 and 3 bytes of value `0x00` to ensure that the
@@ -950,22 +961,23 @@ individual `keyAndValueByteLength` fields.
 === Supercompression Global Data
 ==== supercompressionGlobalData
 An array of data used by certain supercompression schemes that must
-be available before any mip level can be expanded. Must start on an
-the next 8-byte boundary following the key/value data. For some schemes,
-the specification for this data block is given below.
+be available before any mip level can be inflated. Must start on
+the next 8-byte boundary following the key/value data. For some
+schemes, the specification for this data block is given below.
 
 [#basisu_gd]
 ==== Basis Universal Global Data
 
-Basis Universal combines encoding to a subset of a block-compressed
-texture format, that can be easily transcoded to various GPU-native
-block-compressed formats, with lossless supercompression.
-Supercompression is accomplished by processing the block-compressed
-representation in preparation for entropy encoding then Huffman
-encoding the result.  Basis Universal creates a global codebook
-referenced by each supercompressed image that contains processed
-ETC1S endpoint and selector data and the Huffman tables. The global
-data block contains this codebook.
+Basis Universal combines encoding to a block-compressed format with
+lossless supercompression.  The block-compressed format is chosen
+such that it can be easily transcoded to various GPU-native
+block-compressed formats. Typically it is a subset of one of those
+formats.  Supercompression is accomplished by processing the
+block-compressed representation in preparation for entropy encoding
+then Huffman encoding the result.  Basis Universal creates a global
+codebook referenced by each supercompressed image that contains
+processed endpoint and selector data from the block-compression and
+the Huffman tables. The global data block contains this codebook.
 
 It also contains an array of _image descriptors_ with flags for each image
 and the offset and length within the image's mip level of the data for
@@ -1084,7 +1096,7 @@ NOTE: This does not necessarily mean the texture has an alpha component.
 The number of endpoints in <<_endpointsdata,endpointsData>>.
 
 ===== selectorCount
-The number of selectorss in <<_selectorsdata,selectorsData>>.
+The number of selectors in <<_selectorsdata,selectorsData>>.
 
 ===== endpointsByteLength
 The length of <<_endpointsdata,endpointsData>>.
@@ -1461,10 +1473,12 @@ by using the key
 
 -   `KTXastcDecodeMode`
 
-The value `rgb9e5` means that pixel values could be decoded with RGB9E5 mode.
+The value is a NUL-terminated string.
 
-The value `unorm8` (valid only for LDR formats) means that pixel values could
-be decoded witn UNORM8 mode.
+`rgb9e5` means that pixel values can be decoded with RGB9E5 mode.
+
+`unorm8` (valid only for LDR formats) means that pixel values can
+be decoded with UNORM8 mode.
 
 Other values are not allowed.
 
@@ -1536,8 +1550,8 @@ Can we guarantee the DF descriptor blocks are always a multiple of 4 bytes?::
   anything to require that extensions' block sizes be a multiple of
   4 bytes? Need to maintain alignment.
 +
-_Resolved:_ The Data Format Specification will be updated to recommend
-but not require padding. This spec. will require padding.
+_Resolved:_ The Data Format Specification has been updated to
+recommend but not require padding. This spec. will require padding.
 
 Should KTX2 support level sizes > 4GB?::
   _Discussion:_ Users have reported having base levels > 4GB for 3D
@@ -1576,7 +1590,7 @@ Should KTX2 drop the `gl*` fields?::
   `glFormat` and `glType` combination.
 +
 _Resolved:_ Drop the `gl*` fields. OpenGL and OpenGL ES loaders
-can include code to do the mapping based on table which will be
+can include code to do the mapping based on table which has been
 added to the spec. Such code is estimated to be about 6 kbytes.
 
 Use alphanumeric characters or binary values for component swizzles?::

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -160,7 +160,7 @@ until dfdByteLength read
 continue
     UInt32   keyAndValueByteLength
     Byte     keyAndValue[keyAndValueByteLength]
-    align(4) valuePadding   // No padding the last time. <5>
+    align(4) valuePadding <5>
                     [.optional]#&#xFE19;#
 until kvdByteLength read
 align(8)
@@ -172,7 +172,7 @@ align(8)
 // Mip Level Array <7>
 for each mip_level in levelCount <8>
     Byte     levelImages[bytesOfLevelImages] <9>
-    align(8) mipPadding // No padding the last time.
+    align(8) mipPadding
 end
 ----
 <1> Required. See <<Index>>.

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2,7 +2,7 @@
 :author: Mark Callow
 :author_org: Edgewise Consulting
 :description: Specification for container format for OpenGL^®^ and Vulkan^®^ textures.
-:docrev: draft13
+:docrev: draft14
 :ktxver: 2.0
 :revnumber: {ktxver}.{docrev}
 :revdate: {docdate}
@@ -1888,12 +1888,22 @@ This appendix is informative only.
                                     language improvements and fix errors
                                     and typos.
 |      draft12      |  2019-06-05 | Change 22 in identifier to 20.
-|     {docrev}      |  {revdate}  | Rename arrayElementCount. Add ASTC
+|      draft13      |  2019-11-13 | Rename arrayElementCount. Add ASTC
                                     HDR & 3D enums. Add GL API support
                                     info. Update supercompression info
                                     including documenting BasisU global
                                     data and specifying necessary DFDs.
                                     Fix various bugs.
+|     {docrev}      |  {revdate}  | Fix typos, contradictions &
+                                    omissions. Retain component info and
+                                    signed/unsigned-ness in DFD for all
+                                    supercompression schemes. Require
+                                    metadata key lengths be suitable to
+                                    align wide binary numbers and change
+                                    KTXanimation to KTXanimData. Require
+                                    padding after last mip level and
+                                    key/value pair for consistent
+                                    handling.
 |===
 
 [discrete]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1903,7 +1903,8 @@ This appendix is informative only.
                                     KTXanimation to KTXanimData. Require
                                     padding after last mip level and
                                     key/value pair for consistent
-                                    handling.
+                                    handling. Add Metal ASTC HDR
+                                    formats.
 |===
 
 [discrete]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -589,7 +589,7 @@ applicable only to uncompressed images.
   The <<_data_format_descriptor,_Data Format Descriptor_>> must
   retain the pre-deflation color space information and indicate
   which color and alpha components are present.
-  See <<DFD for Basis Universal>>.
+  See <<DFD for Supercompressed Data>>.
 
 * `<<_levelsp_uncompressedbytelength,levels[p].uncompressedByteLength>>`
   must be 0.
@@ -612,7 +612,9 @@ format.
 * `<<_vkformat,vkFormat>>` must retain the pre-deflation value.
   The <<_data_format_descriptor,_Data Format Descriptor_>> must
   retain pre-deflation color space information.
-  See <<DFD for ZLIB and Zstandard>>.
+  retain pre-deflation color space information and indicated which
+  components are present.
+  See <<DFD for Supercompressed Data>>.
 
 ===== Zstandard
 * Only _Zstandard_ frames are required. Inflators may skip _Skippable_
@@ -623,8 +625,9 @@ format.
 
 * `<<_vkformat,vkFormat>>` must retain the pre-deflation value.
   The <<_data_format_descriptor,_Data Format Descriptor_>> must
-  retain pre-deflation color space information.
-  See <<DFD for ZLIB and Zstandard>>.
+  retain pre-deflation color space information and indicated which
+  components are present.
+  See <<DFD for Supercompressed Data>>.
 
 === Index
 An index giving the byte offsets from the start of the file and byte
@@ -802,21 +805,32 @@ Premultiplied Alpha::
 
 ==== Special Cases
 
-===== DFD for Basis Universal
-When `<<_supercompressionscheme,supercompressionScheme>> is 1` the
-_dfDescriptorBlock_ must retain the `colorModel`, `transferFunction`,
-`colorPrimaries`, and `flags` of the pre-Basis Universal-encoding
-image data. It must also indicate which components are present in
-the deflated data.  Thus the DFD will be that of the pre-Basis
-Universal-encoding data with `bytesPlane[0-7]` set to 0 and all
-samples having zero length and offsets to indicate an _unsized
-format_ as described in Section 5.19 "Unsized Formats" of <<KDF13>>.
-`sampleLower` and `sampleUpper` should also be 0. <<example_rg>>
-gives an example DFD for images that had 2 unsigned components prior
-to Basis Universal encoding.
+===== DFD for Supercompressed Data
+When `<<_supercompressionscheme,supercompressionScheme>> is not 0`
+the _dfDescriptorBlock_ must retain the `colorModel`, `transferFunction`,
+`colorPrimaries`, and `flags` of the pre-deflation images. It must
+also indicate which components are present in the deflated images.
+Thus the DFD will be that of the pre-deflation images with
+`bytesPlane[0-7]` set to 0 and all samples having zero length and
+offsets to indicate an _unsized format_ as described in Section
+5.19 "Unsized Formats" of <<KDF13>>.  `sampleLower` should be 0 or
+`INT32_MIN` and `sampleUpper` should be `UINT32_MAX`or `INT32_MAX`
+indicating that the full representable range of the compressed data
+is mapped to 0..1 or -1..1 respectively.
+
+[NOTE]
+====
+In the event that a block-compressed format is supercompressed, wbicb is
+forbidden for Basis Universal, the DFD will reflect the color model of
+the block-compressed format most of which have only one or two
+components.
+====
+
+<<example_rg>> shows a DFD for images that were `VK_FORMAT_R8G8_UNORM`,
+before deflation, i.e. have two unsigned 8-bit components.
 
 [[example_rg]]
-.Example RG descriptor
+.Example Unsigned RG descriptor
 [.dfdexample, width=75%]
 |================================
 32+^| *~++uint32_t++ bit~*
@@ -836,39 +850,51 @@ to Basis Universal encoding.
 8+^| *_~samplePosition3~_* 8+^| *_~samplePosition2~_* 8+^| *_~samplePosition1~_* 8+^| *_~samplePosition0~_*
 8+^| 0 8+^| 0 8+^| 0 8+^| 0
 32+^| *_sampleLower:_* 0
-32+^| *_sampleUpper:_* 0
+32+^| *_sampleUpper:_* UINT32_MAX
 ^| *_~F~_* ^| *_~S~_* ^| *_~E~_* ^| *_~L~_* 4+^| *_~channelType~_* 24+^| ~Green sample information~
 ^| 0 ^| 0 ^| 0 ^| 0 4+^| *++GREEN++* 8+^| *_bitLength:_* 0 16+^| *_bitOffset:_* 0
 8+^| *_~samplePosition3~_* 8+^| *_~samplePosition2~_* 8+^| *_~samplePosition1~_* 8+^| *_~samplePosition0~_*
 8+^| 0 8+^| 0 8+^| 0 8+^| 0
 32+^| *_sampleLower:_* 0
-32+^| *_sampleUpper:_* 0
+32+^| *_sampleUpper:_* UINT32_MAX
 |================================
 
-===== DFD for ZLIB and Zstandard
-When `<<_supercompressionscheme,supercompressionScheme>> is 2, 3
-or 4` the _dfDescriptorBlock_ must retain the `transferFunction`,
-`colorPrimaries`, and `flags` of the pre-deflation image data. It must
-not contain any sample information. The retained pre-deflation `vkFormat`
-value provides sufficient information. Therefore the color model must be
-`KHR_DF_MODEL_UNSPECIFIED`.
-<<example_nosamp>> gives an example DFD.
+<<example_rgb>> shows a DFD for images that were `VK_FORMAT_R8G8B8_SNORM`,
+before deflation, i.e. have 3 signed 8-bit components.
 
-[[example_nosamp]]
-.Example no sample descriptor
+[[example_rgb]]
+.Example Signed RGB descriptor
 [.dfdexample, width=75%]
 |================================
 32+^| *~++uint32_t++ bit~*
 ^| ~31~ ^| ~30~ ^| ~29~ ^| ~28~ ^| ~27~ ^| ~26~ ^| ~25~ ^| ~24~ ^| ~23~ ^| ~22~ ^| ~21~ ^| ~20~ ^| ~19~ ^| ~18~ ^| ~17~ ^| ~16~ ^| ~15~ ^| ~14~ ^| ~13~ ^| ~12~ ^| ~11~ ^| ~10~ ^| ~9~ ^| ~8~ ^| ~7~ ^| ~6~ ^| ~5~ ^| ~4~ ^| ~3~ ^| ~2~ ^| ~1~ ^| ~0~
-32+^| *_totalSize:_* 28
+32+^| *_totalSize:_* 76
 15+^| *_descriptorType:_* 0 17+^| *_vendorId:_* 0
-16+^| *_descriptorBlockSize:_* 24 16+^| *_versionNumber:_* 2
+16+^| *_descriptorBlockSize:_* stem:[24 + (16 \times 3) = 72] 16+^| *_versionNumber:_* 2
 8+^| *_flags:_* *++ALPHA_STRAIGHT++* 8+^| *_transferFunction:_*
-*++LINEAR++* 8+^| *_colorPrimaries:_* *++BT709++* 8+^| *_colorModel:_* *++UNSPECIFIED++*
+*++LINEAR++* 8+^| *_colorPrimaries:_* *++BT709++* 8+^| *_colorModel:_* *++RGBSDA++*
 8+^| *_~texelBlockDimension3~_* 8+^| *_~texelBlockDimension2~_* 8+^| *_~texelBlockDimension1~_* 8+^| *_~texelBlockDimension0~_*
 8+^| 0 8+^| 0 8+^| 0 8+^| 0
 8+^| *_bytesPlane3:_* 0 8+^| *_bytesPlane2:_* 0 8+^| *_bytesPlane1:_* 0 8+^| *_bytesPlane0:_* 0
 8+^| *_bytesPlane7:_* 0 8+^| *_bytesPlane6:_* 0 8+^| *_bytesPlane5:_* 0 8+^| *_bytesPlane4:_* 0
+^| *_~F~_* ^| *_~S~_* ^| *_~E~_* ^| *_~L~_* 4+^| *_~channelType~_* 24+^| ~Red sample information~
+^| 0 ^| 0 ^| 0 ^| 0 4+^| *++RED++* 8+^| *_bitLength:_* 0 16+^| *_bitOffset:_* 0
+8+^| *_~samplePosition3~_* 8+^| *_~samplePosition2~_* 8+^| *_~samplePosition1~_* 8+^| *_~samplePosition0~_*
+8+^| 0 8+^| 0 8+^| 0 8+^| 0
+32+^| *_sampleLower:_* INT32_MIN
+32+^| *_sampleUpper:_* INT32_MAX
+^| *_~F~_* ^| *_~S~_* ^| *_~E~_* ^| *_~L~_* 4+^| *_~channelType~_* 24+^| ~Green sample information~
+^| 0 ^| 0 ^| 0 ^| 0 4+^| *++GREEN++* 8+^| *_bitLength:_* 0 16+^| *_bitOffset:_* 0
+8+^| *_~samplePosition3~_* 8+^| *_~samplePosition2~_* 8+^| *_~samplePosition1~_* 8+^| *_~samplePosition0~_*
+8+^| 0 8+^| 0 8+^| 0 8+^| 0
+32+^| *_sampleLower:_* INT32_MIN
+32+^| *_sampleUpper:_* INT32_MAX
+^| *_~F~_* ^| *_~S~_* ^| *_~E~_* ^| *_~L~_* 4+^| *_~channelType~_* 24+^| ~Blue sample information~
+^| 0 ^| 0 ^| 0 ^| 0 4+^| *++BLUE++* 8+^| *_bitLength:_* 0 16+^| *_bitOffset:_* 0
+8+^| *_~samplePosition3~_* 8+^| *_~samplePosition2~_* 8+^| *_~samplePosition1~_* 8+^| *_~samplePosition0~_*
+8+^| 0 8+^| 0 8+^| 0 8+^| 0
+32+^| *_sampleLower:_* INT32_MIN
+32+^| *_sampleUpper:_* INT32_MAX
 |================================
 
 ==== dfdTotalSize

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -968,13 +968,19 @@ character that terminates the key is the Value data.
 
 The Value data may consist of any arbitrary data bytes. Any byte
 value is allowed. It is encouraged that the value be a NUL terminated
-UTF-8 string without a BOM, but this is not required. If the Value
-data is binary, it is a sequence of bytes rather than of words. It
-is up to the vendor defining the key to specify how those bytes are
-to be interpreted. If any bytes encode multi-byte numbers they must
-be in little-endian order. If the Value data is a string then the
-NUL termination, if present, must be included in `keyAndValueByteLength`
-(but programs that read KTX files must not rely on NUL termination).
+UTF-8 string without a BOM, but this is not required.
+
+If the Value data is binary, it is a sequence of bytes rather than
+of words. It is up to the vendor defining the key to specify how
+those bytes are to be interpreted. If any bytes encode multi-byte
+numbers they must be in little-endian order and, if such a number
+appears at the start of the Value data, the key length including
+its terminating NUL must be a multiple of the number of bytes in
+the number so that the number will be properly aligned.
+
+If the Value data is a string then the NUL termination, if present,
+must be included in `keyAndValueByteLength` (but programs that read
+KTX files must not rely on NUL termination).
 
 ==== valuePadding
 Contains between 0 and 3 bytes of value `0x00` to ensure that the
@@ -1249,10 +1255,10 @@ other combination of parameters makes the KTX file invalid.
 
 === Animation Sequence
 The images of a 2D array texture can be indicated to be the frames
-of a short animation sequence by including <<_ktxanimation,KTXanimation>>
+of a short animation sequence by including <<_ktxanimdata,KTXanimData>>
 metadata. Valid _animation_ files must have the combination of
 parameters outlined in <<Texture Type>> for 2D Array textures in
-addition to KTXanimation metadata. <<_layercount,`layerCount`>> is
+addition to KTXanimData metadata. <<_layercount,`layerCount`>> is
 the number of frames in the video, i.e. layers become the temporal
 axis.
 
@@ -1369,9 +1375,6 @@ When <<formatMapping>> does not have an entry for the value of
 `vkFormat`, which will happen for newly added Vulkan formats, the
 KTX writer must provide any known mapping via the following key-value
 pairs.
-
-Note that the length of these keys, including the terminating `NUL`,
-is a multiple of 4 bytes so the values will be 4-byte aligned.
 
 ==== KTXglFormat
 
@@ -1514,11 +1517,11 @@ use sRGB transfer function.
 This metadata entry has no effect on and should not be present in KTX files that
 use non-ASTC formats.
 
-=== KTXanimation
+=== KTXanimData
 The images of a 2D array texture can be indicated to be the frames of a
 short animation by using the key
 
--   `KTXanimation`
+-   `KTXanimData`
 
 The value is 12 bytes representing 3 Uint32 values:
 [source,c]


### PR DESCRIPTION
The bulk of the changes fix typos, inconsistencies and omissions and do not change the meaning. However some the changes render existing KTX2 files incompatible in the following ways:

* The DFD for Basis Universal compressed images must now retain the signed-/unsigned-ness of the component data.
* The DFD for other supercompression schemes must now also retain the component info of the pre-deflation images. Since I am unaware of any implementations using schemes other than BasisU I don't think anyone will be affected.
* Lengths of metadata keys whose values are wide binary numbers, e.g. uint32_t must be such that the binary value will be properly aligned. This has caused KTXanimation to be changed to KTXanimData (12 chars instead of 13).
* All mip levels and all key/value pairs, including the last, must be padded. Previously the last was not to be padded but the inconsistent handling is problematic for applications.

Fixes #111. Fixes #112.