### PR TITLE
Use dfdTotalSize for DFD definition

### DIFF
--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -166,7 +166,7 @@ UInt32 dfdTotalSize
 continue
     dfDescriptorBlock dfdBlock
           [.optional]#&#xFE19;#
-until dfdByteLength read
+until dfdTotalSize read
 
 // Key/Value Data <.>
 continue


### PR DESCRIPTION
Referring to `dfdTotalSize` here makes this part of the KTX spec more readable and better aligned with the upstream DFD spec.