### PR TITLE
Future proof transferFunction restrictions.

### DIFF
--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -881,7 +881,7 @@ _dfDescriptorBlock_.
   compressed color model listed in <<KDF13>> Section 5.6 or its
   successors, currently `KHR_DF_MODEL_BC1A` to `KHR_DF_MODEL_UASTC`.
   `KHR_DF_MODEL_YUVSDA` should be used for all non-prohibited
-  `+*_422_*+` formats.
+  `+*_422_*+` formats, `KHR_DF_MODEL_RGBSDA` for the rest.
 * If `<<_vkformat,vkFormat>>` is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
 * If `<<_vkformat,vkFormat>>` is not one of the `+*_SRGB{,_*}+` formats

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -885,6 +885,15 @@ _dfDescriptorBlock_.
 * If `<<_vkformat,vkFormat>>` is not one of the `+*_SRGB{,_*}+` formats
   and an sRGB variant of that format exists, `transferFunction` should not
   be `KHR_DF_TRANSFER_SRGB`.
+* If formats for other transfer functions are added to GPU APIs in the
+  future similar restrictions to those just described apply. For
+  example, if formats supporting the HLG transfer function are added
+  having the suffix `_HLG` then
+    - If `<<_vkformat,vkFormat>>` is one of the `+*_HLG{,_*}+` formats
+      `transferFunction` must be `KHR_DF_TRANSFER_HLG`.
+    - If `<<_vkformat,vkFormat>>` is not one of the `+*_HLG{,_*}+`
+      formats and an HLG variant of that format exists,
+      `transferFunction` should not be `KHR_DF_TRANSFER_SRGB`.
 
 [NOTE]
 ====

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -881,8 +881,7 @@ _dfDescriptorBlock_.
   compressed color model listed in <<KDF13>> Section 5.6 or its
   successors, currently `KHR_DF_MODEL_BC1A` to `KHR_DF_MODEL_UASTC`.
   `KHR_DF_MODEL_YUVSDA` should be used for all non-prohibited
-  `+*_422_*+` formats, `VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16`
-  and `VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16`.
+  `+*_422_*+` formats.
 * If `<<_vkformat,vkFormat>>` is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
 * If `<<_vkformat,vkFormat>>` is not one of the `+*_SRGB{,_*}+` formats

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -893,7 +893,7 @@ _dfDescriptorBlock_.
       `transferFunction` must be `KHR_DF_TRANSFER_HLG`.
     - If `<<_vkformat,vkFormat>>` is not one of the `+*_HLG{,_*}+`
       formats and an HLG variant of that format exists,
-      `transferFunction` should not be `KHR_DF_TRANSFER_SRGB`.
+      `transferFunction` should not be `KHR_DF_TRANSFER_HLG`.
 
 [NOTE]
 ====

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -881,7 +881,7 @@ _dfDescriptorBlock_.
   compressed color model listed in <<KDF13>> Section 5.6 or its
   successors, currently `KHR_DF_MODEL_BC1A` to `KHR_DF_MODEL_UASTC`.
   `KHR_DF_MODEL_YUVSDA` should be used for all non-prohibited
-  `+*_422_*+` formats, `KHR_DF_MODEL_RGBSDA` for the rest.
+  `+*_422_*+` formats.
 * If `<<_vkformat,vkFormat>>` is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
 * If `<<_vkformat,vkFormat>>` is not one of the `+*_SRGB{,_*}+` formats

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -877,9 +877,12 @@ _dfDescriptorBlock_.
 * If `<<_vkformat,vkFormat>>` is not `VK_FORMAT_UNDEFINED`, the DFD's
   `texelBlockDimension*`, `bytesPlane*` and sample information fields
   must match the format's definition. The `colorModel` must be
-  `KHR_DF_MODEL_RGBSDA` or the matching block compressed color model
-  listed in <<KDF13>> Section 5.6 or its successors, currently
-  `KHR_DF_MODEL_BC1A` to `KHR_DF_MODEL_UASTC`.
+  `KHR_DF_MODEL_RGBSDA`, `KHR_DF_MODEL_YUVSDA` or the matching block
+  compressed color model listed in <<KDF13>> Section 5.6 or its
+  successors, currently `KHR_DF_MODEL_BC1A` to `KHR_DF_MODEL_UASTC`.
+  `KHR_DF_MODEL_YUVSDA` should be used for all non-prohibited
+  `+*_422_*+` formats, `VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16`
+  and `VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16`.
 * If `<<_vkformat,vkFormat>>` is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
 * If `<<_vkformat,vkFormat>>` is not one of the `+*_SRGB{,_*}+` formats

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -887,8 +887,8 @@ _dfDescriptorBlock_.
   be `KHR_DF_TRANSFER_SRGB`.
 * If formats for other transfer functions are added to GPU APIs in the
   future similar restrictions to those just described apply. For
-  example, if formats supporting the HLG transfer function are added
-  having the suffix `_HLG` then
+  example, if formats for the HLG transfer function which have the
+  the suffix `_HLG` are added then
     - If `<<_vkformat,vkFormat>>` is one of the `+*_HLG{,_*}+` formats
       `transferFunction` must be `KHR_DF_TRANSFER_HLG`.
     - If `<<_vkformat,vkFormat>>` is not one of the `+*_HLG{,_*}+`


### PR DESCRIPTION
@lexaknyazev please review. I want to give direction for how the transferFunction for possible new formats should be handled as the spec already says that formats added to the Vulkan spec. in future can be used.