### PR TITLE
Descriptor Block - incorrect descriptorType bit size

### DIFF
--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1247,7 +1247,7 @@ of <<KDF13>>.
 
 ==== dfdBlock
 A `Descriptor Block` as defined in Section 4.1 of <<KDF13>>. The
-high-order 16 bits of its first UInt32 are the `descriptor_type`
+high-order 15 bits of its first UInt32 are the `descriptor_type`
 and the high-order 16 bits of the second UInt32 are the
 `descriptor_block_size`.  `descriptor_block_size` is mandated to
 be a multiple of 4 which guarantees that the following


### PR DESCRIPTION
Fixes bit size information on Descriptor Block's [descriptorType](https://github.khronos.org/KTX-Specification/ktxspec.v2.html#:~:text=The%20high%2Dorder%2016%20bits%20of%20its%20first%20UInt32%20are%20the%20descriptor_type).

As can be validated in KDF v1.3 section 4.1 - [descriptorType](https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.html#:~:text=descriptorType%20is%20a%20unique%2015%2Dbit%20identifier), and is also correctly reflected in the example tables above.

