### PR TITLE
Add UASTC HDR and XUASTC LDR formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,12 @@ ktx_inlined_images := icons/ktx_favicon.ico \
 appendices=appendices
 
 ktx_sources := ktxspec.adoc \
-           $(appendices)/basisuah66i-gdata.adoc \
-           $(appendices)/basisuah66i-bitstream.adoc \
            $(appendices)/basislz-gdata.adoc \
            $(appendices)/basislz-bitstream.adoc \
+           $(appendices)/basisuah66i-gdata.adoc \
+           $(appendices)/basisuah66i-bitstream.adoc \
+           $(appendices)/basisxual-gdata.adoc \
+           $(appendices)/basisxual-bitstream.adoc \
            $(appendices)/vendor-metadata.adoc \
            ktx-media-registration.adoc \
            license.adoc \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ ktx_inlined_images := icons/ktx_favicon.ico \
 appendices=appendices
 
 ktx_sources := ktxspec.adoc \
+           $(appendices)/basisuah66i-gdata.adoc \
+           $(appendices)/basisuah66i-bitstream.adoc \
            $(appendices)/basislz-gdata.adoc \
            $(appendices)/basislz-bitstream.adoc \
            $(appendices)/vendor-metadata.adoc \

--- a/appendices/basislz-gdata.adoc
+++ b/appendices/basislz-gdata.adoc
@@ -139,3 +139,4 @@ in <<ETC1S Slice Huffman Tables>>.
 === extendedData
 Extended data. This is not used for ETC1S.
 
+// vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basislz-gdata.adoc
+++ b/appendices/basislz-gdata.adoc
@@ -3,7 +3,7 @@
 
 BasisLZ combines encoding to a block-compressed format, that can be easily transcoded to various GPU-native block-compressed formats, with lossless supercompression.  Supercompression is accomplished by conditioning the block-compressed representation for entropy encoding then Huffman encoding the result. BasisLZ creates a global codebook referenced by each supercompressed image that contains the processed endpoint and selector data from the block-compression and the Huffman tables. The global data block contains this codebook.
 
-It also contains an array of _image descriptors_ with flags for each image and the offset and length within the mip level of the data for that image.
+It also contains an array of _image descriptors_ with flags for each image and the offset within its mip level and length of the data for that image.
 
 The global data structure is designed to accommodate various transcodable block-compressed formats. The format in use is indicated by the <<_data_format_descriptor, Data Format Descriptor>>. Currently BasisLZ only supports one, <<etc1s, ETC1S>> (a subset of ETC1, see {url-df-spec}#ETC1S[Section 21.1] of <<KDF14>>).  ETC1S is a common subset of many GPU-native formats.
 

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -8,7 +8,7 @@ The bitstream is as documented in the https://github.com/BinomialLLC/basis_unive
 The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168.
 The bitstream has a https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] of 3 little-endian 16-bit fields.
 The first field is the compression type ID and its value must match that of `rgbSliceType` in the <<basisuah66i_image_desc,ImageDesc>> that refers to the bitstream.
-The second and third fields are the width and height of the texture.
-The value of the width field must equal stem:[\textit{num_blocks_x}] and the value of the height field must equal stem:[\textit{num_blocks_y}] as calculated for the mip level using <<levelImages_defs,these formulae>> with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[1].
+The second and third fields are the width and height of the texture image in pixels.
+The value of the width field must equal stem:[\textit{num_blocks_x}] and the value of the height field must equal stem:[\textit{num_blocks_y}] as calculated for the mip level using <<levelImages_defs,these formulae>>. Since the width and height are in pixels, stem:[\textit{block_width}] and stem:[\textit{block_height}] in those formulae must be stem:[1].
 
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -1,0 +1,9 @@
+[appendix#basisuah66i]
+[#basisuah66i_bitstream]
+== Basis UASTC HDR 6x6 Intermediate Bitstream Specification
+
+_Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the Basis UASTC HDR 6x6 texture format.
+
+For now, see the https://github.com/BinomialLLC/basis_universal/wiki/ASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki.
+
+// vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -4,22 +4,8 @@
 
 _Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the Basis UASTC HDR 6x6 texture format.
 
-The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki, except that the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] is not included when the bitstream is contained in a KTX v2 file. The compression type is signalled by the supercompressionScheme ID and the colorModel in the DFD. The image width and height can be calculated as follows:
+The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki, except that the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] is not included when the bitstream is contained in a KTX v2 file. The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168. The image width and height can be calculated using <<levelImages_defs,these formulae>> for stem:[\textit{num_blocks_x}] and stem:[\textit{num_blocks_y}] with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[1]. The number of unpacked ASTC HDR 6x6 blocks can be calculated using the <<levelImages_defs,same formulae>> but with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[6] then calculating stem:[\textit{num_blocks_x}\times\textit{num_blocks_y}].
 
-[stem]
-// width = max(1, pixelWidth * 2**-p)
-+++++
-\textit{width} = \max\left(1, \lfloor{\texttt{pixelWidth}*{2^{-p}}}\rfloor\right)
-+++++
 
-[stem]
-// height = max(1, pixelHeight * 2**-p)
-+++++
-\textit{height} = \max\left(1, \lfloor{\texttt{pixelHeight}*{2^{-p}}}\rfloor\right)
-+++++
-
-where stem:[p] is the level index.
-
-The number of unpacked ASTC HDR 6x6 blocks in an image is given by <<levelImages_defs,these formulae>> with stem:[\textit{block_depth}] stem:[1], stem:[\textit{block_height}] stem:[6] and stem:[\textit{block_width}] stem:[6].
 
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -4,6 +4,6 @@
 
 _Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the Basis UASTC HDR 6x6 texture format.
 
-For now, see the https://github.com/BinomialLLC/basis_universal/wiki/ASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki.
+For now, see the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki.
 
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -4,7 +4,11 @@
 
 _Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the Basis UASTC HDR 6x6 texture format.
 
-The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki, except that the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] is not included when the bitstream is contained in a KTX v2 file. The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168. The image width and height can be calculated using <<levelImages_defs,these formulae>> for stem:[\textit{num_blocks_x}] and stem:[\textit{num_blocks_y}] with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[1]. The number of unpacked ASTC HDR 6x6 blocks can be calculated using the <<levelImages_defs,same formulae>> but with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[6] then calculating stem:[\textit{num_blocks_x}\times\textit{num_blocks_y}].
-
+The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki.
+The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168.
+The bitstream has a https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] of 3 little-endian 16-bit fields.
+The first field is the compression type ID and its value must match that of `rgbSliceType` in the <<basisuah66i_image_desc,ImageDesc>> that refers to the bitstream.
+The second and third fields are the width and height of the texture.
+The value of the width field must equal stem:[\textit{num_blocks_x}] and the value of the height field must equal stem:[\textit{num_blocks_y}] as calculated for the mip level using <<levelImages_defs,these formulae>> with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[1].
 
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -8,7 +8,7 @@ The bitstream is as documented in the https://github.com/BinomialLLC/basis_unive
 The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168.
 The bitstream has a https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] of 3 little-endian 16-bit fields.
 The first field is a combined ID field containing the entropy profile and stream semantic version with the profile ID in bits 15-8 (the second byte) and the stream semantic version in bits 7-0 (the first byte).
-This field must match the least significant word of (the first two bytes) of `rgbSliceType` in the <<basisuah66i_image_desc,ImageDesc>> that refers to the bitstream.
+This field must match the least significant 16-bits of (the first two bytes) of `rgbSliceType` in the <<basisuah66i_image_desc,ImageDesc>> that refers to the bitstream.
 The second and third fields are the width and height of the texture image in pixels.
 The value of the width field must equal stem:[\textit{num_blocks_x}] and the value of the height field must equal stem:[\textit{num_blocks_y}] as calculated for the mip level using <<levelImages_defs,these formulae>>. Since the width and height are in pixels, stem:[\textit{block_width}] and stem:[\textit{block_height}] in those formulae must be stem:[1].
 

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -4,6 +4,22 @@
 
 _Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the Basis UASTC HDR 6x6 texture format.
 
-For now, see the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki.
+The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki, except that the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] is not included when the bitstream is contained in a KTX v2 file. The compression type is signalled by the supercompressionScheme ID and the colorModel in the DFD. The image width and height can be calculated as follows:
+
+[stem]
+// width = max(1, pixelWidth * 2**-p)
++++++
+\textit{width} = \max\left(1, \lfloor{\texttt{pixelWidth}*{2^{-p}}}\rfloor\right)
++++++
+
+[stem]
+// height = max(1, pixelHeight * 2**-p)
++++++
+\textit{height} = \max\left(1, \lfloor{\texttt{pixelHeight}*{2^{-p}}}\rfloor\right)
++++++
+
+where stem:[p] is the level index.
+
+The number of unpacked ASTC HDR 6x6 blocks in an image is given by <<levelImages_defs,these formulae>> with stem:[\textit{block_depth}] stem:[1], stem:[\textit{block_height}] stem:[6] and stem:[\textit{block_width}] stem:[6].
 
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -7,7 +7,8 @@ _Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the B
 The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki.
 The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168.
 The bitstream has a https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] of 3 little-endian 16-bit fields.
-The first field is the compression type ID and its value must match that of `rgbSliceType` in the <<basisuah66i_image_desc,ImageDesc>> that refers to the bitstream.
+The first field is a combined ID field containing the entropy profile and stream semantic version with the profile ID in bits 15-8 (the second byte) and the stream semantic version in bits 7-0 (the first byte).
+This field must match the least significant word of (the first two bytes) of `rgbSliceType` in the <<basisuah66i_image_desc,ImageDesc>> that refers to the bitstream.
 The second and third fields are the width and height of the texture image in pixels.
 The value of the width field must equal stem:[\textit{num_blocks_x}] and the value of the height field must equal stem:[\textit{num_blocks_y}] as calculated for the mip level using <<levelImages_defs,these formulae>>. Since the width and height are in pixels, stem:[\textit{block_width}] and stem:[\textit{block_height}] in those formulae must be stem:[1].
 

--- a/appendices/basisuah66i-bitstream.adoc
+++ b/appendices/basisuah66i-bitstream.adoc
@@ -7,5 +7,4 @@ _Basis UASTC HDR 6x6 Intermediate_ is a custom supercompression scheme for the B
 The bitstream is as documented in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)[format specification] on the basis_universal Wiki, except that the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header] is not included when the bitstream is contained in a KTX v2 file. The compression type is signalled by `supercompressionScheme` = 4 and `colorModel` = 168. The image width and height can be calculated using <<levelImages_defs,these formulae>> for stem:[\textit{num_blocks_x}] and stem:[\textit{num_blocks_y}] with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[1]. The number of unpacked ASTC HDR 6x6 blocks can be calculated using the <<levelImages_defs,same formulae>> but with stem:[\textit{block_width}] and stem:[\textit{block_height}] stem:[6] then calculating stem:[\textit{num_blocks_x}\times\textit{num_blocks_y}].
 
 
-
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-gdata.adoc
+++ b/appendices/basisuah66i-gdata.adoc
@@ -65,8 +65,8 @@ The offset of the start of the RGB slice within the <<levelImagesDesc,levelImage
 
 [[basisuah66i_rgbSliceType]]
 ==== rgbSliceType
-The compression type used in the bitstream for this slice.
-The least significant 16-bits (the first two bytes) of this value must equal the compression type ID, of the bitstream for this slice as described in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header section] of the bitstream specification.
+The combined ID field containing the entropy profile and stream semantic version used in the bitstream for this slice.
+The least significant 16-bits (the first two bytes) of this value must equal the first 16-bits of the bitstream for this slice as described in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header section] of the bitstream specification.
 The most significant 16-bits (the last two bytes) must be 0.
 [NOTE]
 .Rationale

--- a/appendices/basisuah66i-gdata.adoc
+++ b/appendices/basisuah66i-gdata.adoc
@@ -1,7 +1,7 @@
 [appendix#basisuah66i_gd]
 == Basis UASTC HDR 6x6 Intermediate Global Data
 
-Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H or RGB9E5, with lossless supercompression. The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks. Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset and length within its mip level of the data for that image.
+Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H unsigned, with lossless supercompression. The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks. Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset and length within its mip level of the data for that image.
 
 
 [[basisuah66i_global_data_structure]]

--- a/appendices/basisuah66i-gdata.adoc
+++ b/appendices/basisuah66i-gdata.adoc
@@ -1,7 +1,7 @@
 [appendix#basisuah66i_gd]
 == Basis UASTC HDR 6x6 Intermediate Global Data
 
-Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H unsigned, with lossless supercompression. The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks. Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset and length within its mip level of the data for that image.
+Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H unsigned, with lossless supercompression. The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks. Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset within its mip level and the length of the data for that image.
 
 
 [[basisuah66i_global_data_structure]]

--- a/appendices/basisuah66i-gdata.adoc
+++ b/appendices/basisuah66i-gdata.adoc
@@ -7,7 +7,7 @@ Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate crea
 
 
 [[basisuah66i_global_data_structure]]
-.Basis UASTC HDR 6x6 Global Data Structure
+.Basis UASTC HDR 6x6 Intermediate Global Data Structure
 [source,c,subs="+quotes,+attributes,+replacements"]
 ----
 ImageDesc[imageCount] imageDescs;
@@ -20,7 +20,7 @@ ImageDesc[imageCount] imageDescs;
 ----
 UInt32 rgbSliceByteOffset
 UInt32 rgbSliceByteLength
-UInt32 rgbSliceType
+UInt32 sliceProfile
 ----
 
 Descriptions in the `imageDescs` array are in the order layer, face and z_slice as if arranged by the following pseudo code.
@@ -63,11 +63,12 @@ The offset of the start of the RGB slice within the <<levelImagesDesc,levelImage
 
 `rgbSliceByteOffset + rgbSliceByteLength` must not be greater than the byte length of the corresponding mip level.
 
-[[basisuah66i_rgbSliceType]]
-==== rgbSliceType
+[[basisuah66i_sliceProfile]]
+==== sliceProfile
 The combined ID field containing the entropy profile and stream semantic version used in the bitstream for this slice.
-The least significant 16-bits (the first two bytes) of this value must equal the first 16-bits of the bitstream for this slice as described in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header section] of the bitstream specification.
+The least significant 16 bits (the first two bytes) of this value must equal the first 16-bits of the bitstream for this slice as described in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header section] of the bitstream specification.
 The most significant 16-bits (the last two bytes) must be 0.
+Implementations must fail gracefully when encountering an unknown profile or codec variant.
 [NOTE]
 .Rationale
 ====

--- a/appendices/basisuah66i-gdata.adoc
+++ b/appendices/basisuah66i-gdata.adoc
@@ -1,0 +1,62 @@
+[appendix#basisuah66i_gd]
+== Basis UASTC HDR 6x6 Intermediate Global Data
+
+Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H or RGB9E5, with lossless supercompression. The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks. Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset and length within its mip level of the data for that image.
+
+
+[[basisuah66i_global_data_structure]]
+.Basis UASTC HDR 6x6 Global Data Structure
+[source,c,subs="+quotes,+attributes,+replacements"]
+----
+ImageDesc[imageCount] imageDescs;
+----
+
+`ImageDesc` is the following structure.
+
+.ImageDesc
+[source,c]
+----
+UInt32 rgbSliceByteOffset
+UInt32 rgbSliceByteLength
+----
+
+Descriptions in the `imageDescs` array are in the order layer, face and z_slice as if arranged by the following pseudo code.
+[source,c]
+----
+for each level in max(levelCount, 1)
+    for each layer in max (layerCount, 1)
+        for each face in faceCount // 1 or 6
+            for each z_slice in max((pixelDepth of level), 1)
+----
+
+`imageCount` is the total number of images in the Mip Level Array.
+
+[TIP]
+====
+`imageCount` may be calculated as follows:
+[source,c]
+----
+int imageCount = max(layerCount, 1) * faceCount * layerPixelDepth;
+
+// where layerPixelDepth can be derived as
+int layerPixelDepth = max(pixelDepth, 1);
+for(int i = 1; i < levelCount; i++)
+    layerPixelDepth += max(pixelDepth >> i, 1);
+----
+====
+
+There must be no trailing bytes in the global data section after the array of image descriptors, i.e., the following condition must always be true:
+[source,c]
+----
+sgdByteLength == imageCount * 8
+----
+
+=== ImageDesc
+==== rgbSliceByteOffset, rgbSliceByteLength
+The offset of the start of the RGB slice within the <<levelImagesDesc,levelImages>> of its mip level and its byte length. The offset of <<levelImagesDesc,levelImages>> within the file is given in the <<_level_index,Level Index>>.
+
+`rgbSliceByteLength` must not be zero.
+
+`rgbSliceByteOffset + rgbSliceByteLength` must not be greater than the byte length of the corresponding mip level.
+
+// vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisuah66i-gdata.adoc
+++ b/appendices/basisuah66i-gdata.adoc
@@ -1,7 +1,9 @@
 [appendix#basisuah66i_gd]
 == Basis UASTC HDR 6x6 Intermediate Global Data
 
-Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H unsigned, with lossless supercompression. The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks. Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset within its mip level and the length of the data for that image.
+Basis UASTC HDR 6x6 Intermediate format combines encoding to the UASTC HDR 6x6 subset of ASTC, that can be easily transcoded to BC6H unsigned, with lossless supercompression.
+The format uses a small number of variable bit length command codes which can output one or more blocks, and which can reuse parts of previously encoded blocks.
+Because of the variable size of each image Basis UASTC HDR 6x6 Intermediate creates a global data structure that contains an array of _image descriptors_ with the offset within its mip level and the length of the data for that image.
 
 
 [[basisuah66i_global_data_structure]]
@@ -18,6 +20,7 @@ ImageDesc[imageCount] imageDescs;
 ----
 UInt32 rgbSliceByteOffset
 UInt32 rgbSliceByteLength
+UInt32 rgbSliceType
 ----
 
 Descriptions in the `imageDescs` array are in the order layer, face and z_slice as if arranged by the following pseudo code.
@@ -48,9 +51,10 @@ for(int i = 1; i < levelCount; i++)
 There must be no trailing bytes in the global data section after the array of image descriptors, i.e., the following condition must always be true:
 [source,c]
 ----
-sgdByteLength == imageCount * 8
+sgdByteLength == imageCount * 12
 ----
 
+[[basisuah66i_image_desc]]
 === ImageDesc
 ==== rgbSliceByteOffset, rgbSliceByteLength
 The offset of the start of the RGB slice within the <<levelImagesDesc,levelImages>> of its mip level and its byte length. The offset of <<levelImagesDesc,levelImages>> within the file is given in the <<_level_index,Level Index>>.
@@ -58,5 +62,16 @@ The offset of the start of the RGB slice within the <<levelImagesDesc,levelImage
 `rgbSliceByteLength` must not be zero.
 
 `rgbSliceByteOffset + rgbSliceByteLength` must not be greater than the byte length of the corresponding mip level.
+
+[[basisuah66i_rgbSliceType]]
+==== rgbSliceType
+The compression type used in the bitstream for this slice.
+The least significant 16-bits (the first two bytes) of this value must equal the compression type ID, of the bitstream for this slice as described in the https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#header[header section] of the bitstream specification.
+The most significant 16-bits (the last two bytes) must be 0.
+[NOTE]
+.Rationale
+====
+Implementations can use this field to check for an unsupported version without having to load the data.
+====
 
 // vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisxual-bitstream.adoc
+++ b/appendices/basisxual-bitstream.adoc
@@ -1,0 +1,18 @@
+[appendix#basisxual]
+[#basisxual_bitstream]
+== Basis XUASTC LDR Bitstream Specification
+
+_Basis XUASTC LDR_ is a custom supercompression scheme for the Basis XUASTC texture format which is a subset of ASTC.
+The first byte of the bitstream indicates which of three _entropy profiles_ the bitstream corresponds to.
+
+The Full Arithmetic and Hybrid profile bitstreams are documented in https://github.com/BinomialLLC/basis_universal/wiki/XUASTC-LDR-Arithmetic-Profile[XUASTC LDR Arithmetic Profile].
+
+The Full Zstd profile bitstream specification is documented in https://github.com/BinomialLLC/basis_universal/wiki/XUASTC-LDR-Specification-v1.0#xuastc-ldr-byte-stream---full-zstd-profile[XUASTC LDR Byte Stream - Full Zstd Profile]
+
+The compression type is signalled by `supercompressionScheme` = 5.
+The first byte of the bitstream must match bits 0-7 of `sliceProfile` in the <<basisxual_image_desc,ImageDesc>> that refers to the bitstream. The _Stream Version_, the first 5 bits of the https://github.com/BinomialLLC/basis_universal/wiki/XUASTC-LDR-Arithmetic-Profile[_System Header_] which starts at the second byte of the bitstream, must match bits 8-12 of the `sliceProfile`.
+The width and height of the texture image in pixels are given by the _Actual Width_ and _Actual Height_ fields of the _System Header_.
+They must not be zero.
+_Actual Width_ must equal stem:[\textit{num_blocks_x}] and _Actual Height_ must equal stem:[\textit{num_blocks_y}] as calculated for the mip level using <<levelImages_defs,these formulae>>. Since the width and height are in pixels, stem:[\textit{block_width}] and stem:[\textit{block_height}] in those formulae must be stem:[1].
+
+// vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/appendices/basisxual-gdata.adoc
+++ b/appendices/basisxual-gdata.adoc
@@ -1,0 +1,86 @@
+[appendix#basisxual_gd]
+== Basis XUASTC LDR Global Data
+
+The Basis XUASTC LDR format combines encoding to a subset of ASTC LDR, that can be easily transcoded to ASTC or BC7, with DCT based supercompression of the ASTC logical block parameters.
+
+Because of the variable size of each image, Basis XUASTC LDR creates a global data structure that contains an array of _image descriptors_ with the offset within its mip level and the length of the data for that image.
+
+
+[[basisxual_global_data_structure]]
+.Basis XUASTC LDR Global Data Structure
+[source,c,subs="+quotes,+attributes,+replacements"]
+----
+ImageDesc[imageCount] imageDescs;
+----
+
+`ImageDesc` is the following structure.
+
+.ImageDesc
+[source,c]
+----
+UInt32 rgbaSliceByteOffset
+UInt32 rgbaSliceByteLength
+UInt32 sliceProfile
+----
+
+Descriptions in the `imageDescs` array are in the order layer, face and z_slice as if arranged by the following pseudo code.
+[source,c]
+----
+for each level in max(levelCount, 1)
+    for each layer in max (layerCount, 1)
+        for each face in faceCount // 1 or 6
+            for each z_slice in max((pixelDepth of level), 1)
+----
+
+`imageCount` is the total number of images in the Mip Level Array.
+
+[TIP]
+====
+`imageCount` may be calculated as follows:
+[source,c]
+----
+int imageCount = max(layerCount, 1) * faceCount * layerPixelDepth;
+
+// where layerPixelDepth can be derived as
+int layerPixelDepth = max(pixelDepth, 1);
+for(int i = 1; i < levelCount; i++)
+    layerPixelDepth += max(pixelDepth >> i, 1);
+----
+====
+
+There must be no trailing bytes in the global data section after the array of image descriptors, i.e., the following condition must always be true:
+[source,c]
+----
+sgdByteLength == imageCount * 12
+----
+
+[[basisxual_image_desc]]
+=== ImageDesc
+==== rgbaSliceByteOffset, rgbaSliceByteLength
+The offset of the start of the slice within the <<levelImagesDesc,levelImages>> of its mip level and its byte length. The offset of <<levelImagesDesc,levelImages>> within the file is given in the <<_level_index,Level Index>>.
+
+`rgbaSliceByteLength` must not be zero.
+
+`rgbaSliceByteOffset + rgbaSliceByteLength` must not be greater than the byte length of the corresponding mip level.
+
+[[basisxual_sliceProfile]]
+==== sliceProfile
+The profile field containing the entropy profile and codec variant used in the bitstream for this slice.
+The entropy profile used by the slice is given in bits 0-7, the first byte.
+Three profiles are currently known: Full Arithmetic (1), Hybrid (2), and Full Zstd (3).
+The codec variant is given in bits 8-15, the second byte.
+One variant is currently known, signalled by the value 1.
+
+The entropy profile, the first byte, must match the first byte of a slice's bitstream.
+The codec variant value must match the 5-bit _Stream Version_ found at the start of the _System Header_ which begins at the second byte of a slice's bitstream in all profiles.
+The Full Arithmetic and Hybrid profiles' _System Header_ is described https://github.com/BinomialLLC/basis_universal/wiki/XUASTC-LDR-Arithmetic-Profile[here].
+The Full Zstd profile's uses the same _System Header_ though the description is repeated in the Full Zstd bitstream documentation.
+The most significant 16-bits (the last two bytes) must be 0.
+Implementations must fail gracefully when encountering an unknown profile or codec variant.
+[NOTE]
+.Rationale
+====
+Implementations can use this field to check for an unsupported version without having to load the data.
+====
+
+// vim: filetype=asciidoc ai expandtab tw=0 ts=4 sts=2 sw=2

--- a/docinfo.html
+++ b/docinfo.html
@@ -4,11 +4,15 @@ body {
   /* Put Khronos ribbon on left side */
   background-attachment: fixed;
   background-image: url(images/logo-spec.svg);
-  background-position: left top;
+  background-position: right top;
   background-repeat: no-repeat/*, no-repeat*/;
-  /* Override default Asciidoctor margin settings to center the page. */
-  margin: 2em auto 2em auto;
-  max-width: 60em;
+  /* If wider than in #content below, this adds extra margin. */
+  max-width: 100em;
+}
+
+#content {
+  /* Override max from khronos.css. */
+  max-width: 62.5em
 }
 
 div.legal p {

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -656,10 +656,11 @@ uses global data. The format of the global data for a scheme
 is specified in the reference given in the _Global Data Format_
 column of <<supercompressionSchemes>>.
 
-Image data may be conditioned with Rate-distortion Optimization prior to
-supercompression to further reduce the final size. This is transparent
-to the user of the texture so KTX provides no indication that RDO has
-been used.
+Image data may be conditioned with Rate-Distortion Optimization
+prior to supercompression to improve compressibility, further
+reducing the final size. This is an encoding detail which is
+transparent to the user of the texture so KTX provides no indication
+that RDO has been used.
 
 When a supercompression scheme is used, the image data must be
 inflated from the scheme prior to GPU sampling.

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -327,12 +327,12 @@ in {url-vk-docs-sp-chapters}/formats.html[Formats] on <<VULKAN-DOCS>>.
 
 Use of the value `VK_FORMAT_UNDEFINED` (0) is only permissible when
 the format of the data is a not a recognized Vulkan format, such
-as in the case of the universal texture formats. In this case
-information about the format must be provided by the Data Format
-Descriptor and, in cases where the format is known to another GPU
-API, the KTX writer must include one or more of the metadata items
-described in <<formatMappingMetadata>>.  Some permissible uses are
-outlined within this specification and summarized in
+as in the case of some of the universal texture formats. In this
+case information about the format must be provided by the Data
+Format Descriptor and, in cases where the format is known to another
+GPU API, the KTX writer must include one or more of the metadata
+items described in <<formatMappingMetadata>>.  Some permissible
+uses are outlined within this specification and summarized in
 <<Use of `VK_FORMAT_UNDEFINED`>>.
 
 The table in <<formatMapping>> gives the mapping for all `VkFormat`

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -635,8 +635,7 @@ supercompression.
 | 1                    | BasisLZ         | <<etc1s_slice,ETC1S Slice Decoding>>  | <<basislz_gd,BasisLZ Global Data>>
 | 2                    | Zstandard       | <<RFC8478>>       | n/a
 | 3                    | ZLIB            | <<RFC1950>>       | n/a
-| 4                    | Basis GPU Photo 6x6 | https://github.com/BinomialLLC/basis_universal/wiki/ASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)        | n/a
-| 5･･･0xffff           | Reserved^1^     |                   |
+| 4･･･0xffff           | Reserved^1^     |                   |
 | 0x10000･･･0x1ffff    | Reserved^2^     |                   |
 | 0x20000･･･0xffffffff | Reserved^3^     |                   |
 |===
@@ -721,7 +720,8 @@ Therefore it is applicable only to uncompressed images.
 //
 // The PR must also add a note to Vendor Scheme Notes below.
 | 0x10000              | Asobo         | KTX_SS_PROPRIETARY_ASOBO | Asobo Studio | Julien Vernay link:mailto:jvernay@asobostudio.com?subject=(KTX2-Asobo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]jvernay@asobostudio.com,window=_blank,opts=nofollow] | Proprietary | Required
-| 0x10001･･･0x1ffff    | Reserved^2^   |      |          |                              |                   |
+| 0x10001              | Basis GPU Photo 6x6 | KTX_SS_BASIS_GPU_PHOTO_BINOMIAL | Binomial Llc | Some Body link:mailto:aaa@binomial.info?subject=(KTX2-GPU%20Photo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]aaa@binomial.info,window=_blank,opts=nofollow] | Proprietary | Required
+| 0x10002･･･0x1ffff    | Reserved^2^   |      |          |                              |                   |
 |===
 
 [small]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -720,7 +720,9 @@ Therefore it is applicable only to uncompressed images.
 //
 // The PR must also add a note to Vendor Scheme Notes below.
 | 0x10000              | Asobo         | KTX_SS_PROPRIETARY_ASOBO | Asobo Studio | Julien Vernay link:mailto:jvernay@asobostudio.com?subject=(KTX2-Asobo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]jvernay@asobostudio.com,window=_blank,opts=nofollow] | Proprietary | Required
-| 0x10001              | Basis GPU Photo 6x6 | KTX_SS_BASIS_GPU_PHOTO_BINOMIAL | Binomial Llc | Some Body link:mailto:aaa@binomial.info?subject=(KTX2-GPU%20Photo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]aaa@binomial.info,window=_blank,opts=nofollow] | Proprietary | Required
+| 0x10001              | Basis GPU Photo 6x6 |
+KTX_SS_BASIS_GPU_PHOTO_BINOMIAL | Binomial Llc | Some Body
+link:mailto:aaa@binomial.info?subject=(KTX2-GPU%20Photo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]aaa@binomial.info,window=_blank,opts=nofollow] | https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6) | n/a
 | 0x10002･･･0x1ffff    | Reserved^2^   |      |          |                              |                   |
 |===
 

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -656,22 +656,18 @@ uses global data. The format of the global data for a scheme
 is specified in the reference given in the _Global Data Format_
 column of <<supercompressionSchemes>>.
 
-Image data may be conditioned with Rate-Distortion Optimization
-prior to supercompression to improve compressibility, further
-reducing the final size. This is an encoding detail which is
-transparent to the user of the texture so KTX provides no indication
-that RDO has been used.
-
 When a supercompression scheme is used, the image data must be
 inflated from the scheme prior to GPU sampling.
 
 [TIP]
 ====
-LZW-style lossless supercompression, e.g, scheme 2, is generally
-ineffective on the block-compressed data of GPU texture formats.
-It is best reserved for use with uncompressed texture formats or
-with block-compressed data that has been specially conditioned for
-LZW compression such as by _Rate-distortion Optimization_ <<RDO>>.
+Depending on the content of the image, LZW-style lossless
+supercompression, e.g, scheme 2, may be ineffective on the
+block-compressed data of GPU texture formats. Compressibility can
+be improved by specially conditioning the data for LZW compression
+such as with _Rate-distortion Optimization_ <<RDO>>. Such conditioning
+in an encoding detail which is transparent to the user of the
+texture.
 
 BasisLZ internally uses a universal block-compressed
 texture format and Rate-distortion Optimization. Encoding to the

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -541,7 +541,7 @@ If `faceCount` is equal to 6, `pixelHeight` must be equal to
 `pixelWidth`, and `pixelDepth` must be 0.
 
 `pixelHeight` must not be 0 for block-compressed formats, including
-BasisLZ/ETC1S, UASTC, UASTC HDR and UASTC HDR 6x6 Intermediate.
+BasisLZ/ETC1S, UASTC, UASTC HDR 4x4 and UASTC HDR 6x6 Intermediate.
 
 `pixelDepth` must not be 0 for block-compressed formats that have
 block depth greater than 1.
@@ -1161,7 +1161,7 @@ The bitstream of the UASTC data is described in Chapter 25
 {url-df-spec}#UASTC[_UASTC Compressed Texture Image Format_] of
 <<KDF14>>.
 
-Basis Universal ASTC HDR 4x4 Format::
+Basis Universal UASTC HDR 4x4 Format::
 The Universal ASTC HDR 4x4 image format (UASTC HDR 4x4) is a strict
 RGB-only subset of ASTC HDR 4x4. `vkFormat` must be set to
 `VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). The DFD must be
@@ -1184,7 +1184,7 @@ This color model has a single channel with id
 +
 The bitstream of the UASTC HDR 4x4 data is described in <<UASTCHDR44>>.
 
-Basis Universal ASTC HDR 6x6 Format::
+Basis Universal UASTC HDR 6x6 Format::
 The Universal ASTC HDR 6x6 image format (UASTC HDR 6x6) is a custom
 format based off ASTC HDR 6x6 that underlies the
 <<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2189,6 +2189,19 @@ must not be set if the content includes other block dimensions. Such
 blocks must be re-encoded to BC7 preferably by bounded-time O(1) analytical
 encoding.
 
+This metadata entry may only be used with:
+
+* `vkFormat == VK_FORMAT_UNDEFINED`
+
+* `supercompressionScheme == 5`, Basis XUASTC LDR
+
+It must not be used with 
+
+* `KTXxuastcDeblockFilter` metadata.
+
+If `KTXxuastcBc7Transcodable` appears in a KTX file violating these
+constraints, the file is invalid.
+
 === KTXxuastcDeblockFilter
 When XUASTC images are re-encoded to another format, an adaptive
 deblocking filter can be applied to reduce artifacts. Typically
@@ -2206,6 +2219,19 @@ The value is a one-byte NUL-terminated string formatted as (<<REGEXP>>):
 
 where 'd' means disable filtering, 'n' means apply the normal
 filter, and 's' mean apply the strong filter.
+
+This metadata entry may only be used with:
+
+* `vkFormat == VK_FORMAT_UNDEFINED`
+
+* `supercompressionScheme == 5`, Basis XUASTC LDR
+
+It must not be used with 
+
+* `KTXxuastcBc7Transcodable` metadata.
+
+If `KTXxuastcDeblockFilter` appears in a KTX file violating these
+constraints, the file is invalid.
 
 [NOTE]
 ====

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2177,19 +2177,25 @@ existing components. E.g, if blue and alpha are missing they must remain
 as 0.0 and 1.0.
 
 === KTXxuastcBc7Transcodable
-Most 4x4, 6x6 and 8x6 XUASTC LDR blocks can be simply transcoded direct
-to BC7. Exclusive use of transcodable blocks can be signalled by using
-the key
+All XUASTC LDR block dimensions can be simply transcoded to ASTC.
+Most 4x4, 6x6 and 8x6 XUASTC LDR blocks can be simply transcoded
+also to BC7. That the content exclusively uses BC7-transcodable
+blocks can be signalled by using the key
 
 -   `KTXxuastcBc7Transcodable`
 
-The key has no value. It's presence signals transcodability.
+The key has no value. Its presence signals BC7 transcodability. The key
+must not be set if the content includes other block dimensions. Such
+blocks must be re-encoded to BC7 preferably by bounded-time O(1) analytical
+encoding.
 
 === KTXxuastcDeblockFilter
 When XUASTC images are re-encoded to another format, an adaptive
-deblocking filter can be applied to reduce artifacts. This is done by
-default for block sizes > 8x6. Adaptive deblocking can be requested for
-other block sizes or disabled by using the key
+deblocking filter can be applied to reduce artifacts. Typically
+transcoders disable this for block dimensions < 8x6 and apply it
+by default for block dimensions > 8x6. They may apply stronger
+deblocking for block dimensions > 8x8. Preferred deblocking can be
+signalled by using the key
 
 -   `KTXxuastcDeblockFilter`
 
@@ -2198,8 +2204,15 @@ The value is a one-byte NUL-terminated string formatted as (<<REGEXP>>):
 [no-bullet]
 -   `/^[dns]{1}$/`
 
-where 'n' means do not apply a filter, 'd' means apply the default
+where 'd' means disable filtering, 'n' means apply the normal
 filter, and 's' mean apply the strong filter.
+
+[NOTE]
+====
+Some implementations may provide deblocking shaders for application
+which puts deblocking in the control of the application. They should
+use this metadata as a guide.
+====
 
 
 == An example KTX version 2 file:

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -541,7 +541,7 @@ If `faceCount` is equal to 6, `pixelHeight` must be equal to
 `pixelWidth`, and `pixelDepth` must be 0.
 
 `pixelHeight` must not be 0 for block-compressed formats, including
-BasisLZ/ETC1S, UASTC, UASTC HDR and GPU Photo.
+BasisLZ/ETC1S, UASTC, UASTC HDR and UASTC HDR 6x6 Intermediate.
 
 `pixelDepth` must not be 0 for block-compressed formats that have
 block depth greater than 1.
@@ -635,7 +635,8 @@ supercompression.
 | 1                    | BasisLZ         | <<etc1s_slice,ETC1S Slice Decoding>>  | <<basislz_gd,BasisLZ Global Data>>
 | 2                    | Zstandard       | <<RFC8478>>       | n/a
 | 3                    | ZLIB            | <<RFC1950>>       | n/a
-| 4･･･0xffff           | Reserved^1^     |                   |
+| 4                    | Basis UASTC 6x6 Intermediate | <<basisuah66i_bitstream,Basis UASTC HDR 6x6 Intermediate Bitstream Specification>> | <<basisuah66i_gd, Basis UASTC HDR 6x6 Intermediate Global Data>>
+| 5･･･0xffff           | Reserved^1^     |                   |
 | 0x10000･･･0x1ffff    | Reserved^2^     |                   |
 | 0x20000･･･0xffffffff | Reserved^3^     |                   |
 |===
@@ -720,10 +721,7 @@ Therefore it is applicable only to uncompressed images.
 //
 // The PR must also add a note to Vendor Scheme Notes below.
 | 0x10000              | Asobo         | KTX_SS_PROPRIETARY_ASOBO | Asobo Studio | Julien Vernay link:mailto:jvernay@asobostudio.com?subject=(KTX2-Asobo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]jvernay@asobostudio.com,window=_blank,opts=nofollow] | Proprietary | Required
-| 0x10001              | Basis GPU Photo 6x6 |
-KTX_SS_BASIS_GPU_PHOTO_BINOMIAL | Binomial Llc | Some Body
-link:mailto:aaa@binomial.info?subject=(KTX2-GPU%20Photo)%20...question...&body=...who%20are%20you%20and%20your%20question...[icon:send[role="black"]aaa@binomial.info,window=_blank,opts=nofollow] | https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6) | n/a
-| 0x10002･･･0x1ffff    | Reserved^2^   |      |          |                              |                   |
+| 0x10001･･･0x1ffff    | Reserved^2^   |      |          |                              |                   |
 |===
 
 [small]
@@ -790,6 +788,21 @@ transcode target format is selected.
   The <<_data_format_descriptor,_Data Format Descriptor_>> must
   retain pre-deflation color space information and indicate which
   components are present. See <<DFD for Supercompressed Data>>.
+
+[#basisuah66_scheme]
+===== Basis UASTC HDR 6x6 Intermediate
+* <<Basis UASTC HDR 6x6 Intermediate Bitstream Specification>>
+  describes the bitstream for a single image (slice).
+* UASTC slice locations within a mip level are defined exclusively
+  by the corresponding `ImageDesc` structures from the
+  <<basisuah66i_global_data_structure>>. The same slice data may be
+  used by multiple `ImageDesc` structures within the mip level.
+* <<_vkformat,`vkFormat`>> must be `VK_FORMAT_UNDEFINED` (0x00).
+  The <<_data_format_descriptor,_Data Format Descriptor_>> must
+  retain the pre-deflation color space information.
+  See <<DFD for Supercompressed Data>>.
+* `<<_levelsp_uncompressedbytelength,levels[p].uncompressedByteLength>>`
+  must be 0.
 
 [#vendorSchemeNotes]
 ////
@@ -1107,7 +1120,7 @@ The Universal ASTC image format (UASTC) is indicated by `colorModel`
 block-compressed format or decoded to a GPU-supported uncompressed
 format before being uploaded to and sampled by a GPU. UASTC images
 can be supercompressed with any scheme except BasisLZ
-(`supercompressionScheme` = 1) and Basis GPU Photo 6x6
+(`supercompressionScheme` = 1) and Basis UASTC HDR 6x6 Intermediate
 (`supercompressionScheme` = 4). If supercompression is used, the
 DFD must follow the rules described in the next
 <<dfdSupercompressed,subsection>>.
@@ -1148,26 +1161,55 @@ The bitstream of the UASTC data is described in Chapter 25
 {url-df-spec}#UASTC[_UASTC Compressed Texture Image Format_] of
 <<KDF14>>.
 
-Basis Universal ASTC HDR Format::
-The Universal ASTC HDR image format (UASTC HDR) is indicated by
-`colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167). This format supports
-two compression ratios defined by the texel block size in the DFD:
-4x4 and 6x6. Images in this format are a strict RGB-only ASTC HDR
-subset so `vkFormat` must be set to whichever of
-`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000) or
-`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK` (= 1000066004) matches the texel
-block size. The DFD must be as described in Section ??? of <<KDF14>>.
-Images in this format must be transcoded to BC6H or decoded to raw
-16-bit floating-point values before being uploaded to and sampled
-by a GPU that does not support ASTC HDR.  UASTC HDR images can be
+Basis Universal ASTC HDR 4x4 Format::
+The Universal ASTC HDR 4x4 image format (UASTC HDR 4x4) is a strict
+RGB-only subset of ASTC HDR 4x4. `vkFormat` must be set to
+`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). The DFD must be
+as described in Section 5.6.10
+{url-df-spec}#KHR_DF_MODEL_ASTC[_KHR_DF_MODEL_ASTC_] of <<KDF14>>
+but `colorModel` must be `KHR_DF_MODEL_UASTC_HDR_4x4` (= 167) and
+`texelBlockDimension[01]` must be 4.  Images in this format must
+be transcoded to a format supported by the device before being
+uploaded to and sampled by a GPU that does not support ASTC HDR,
+e.g.  `VK_FORMAT_BC6H_UFLOAT_BLOCK`, `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`
+or `VK_FORMAT_R16G16B16A16_SFLOAT`.  UASTC HDR 4x4 images can be
 supercompressed with any scheme except BasisLZ (`supercompressionScheme`
-= 1) and Basis GPU Photo 6x6 (`supercompressionScheme` = 4). If
-supercompression is used, the DFD must follow the rules described
+= 1) and Basis UASTC HDR 6x6 Intermediate (`supercompressionScheme`
+= 4).  If supercompression is used, the DFD must follow the rules
+described in the next <<dfdSupercompressed,subsection>>.
++
+This color model has a single channel with id
+`KHR_DF_CHANNEL_UASTC_HDR_4x4_RGB` (= 0) for which the
+`KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
++
+The bitstream of the UASTC HDR 4x4 data is described in <<UASTCHDR44>>.
+
+Basis Universal ASTC HDR 6x6 Format::
+The Universal ASTC HDR 6x6 image format (UASTC HDR 6x6) is a custom
+format based off ASTC HDR 6x6 that underlies the
+<<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>
+supercompression scheme (`supercompressionScheme`
+= 4).  `vkFormat` must be set to `VK_FORMAT_UNDEFINED` (= 0).  The
+DFD must be as described in Section 5.6.10
+{url-df-spec}#KHR_DF_MODEL_ASTC[_KHR_DF_MODEL_ASTC_] of <<KDF14>>
+but `colorModel` must be `KHR_DF_MODEL_UASTC_6x6_HDR` (= 168) and
+`texelBlockDimension[01]` must be 6. Images in this format are
+RGB-only and are always supercompressed with the
+<<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>
+scheme and must be inflated and transcoded to a
+format supported by the device before being uploaded to and sampled
+by a GPU, e.g `VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK`,
+`VK_FORMAT_BC6H_UFLOAT_BLOCK`, `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`
+or `VK_FORMAT_R16G16B16A16_SFLOAT`.  Because UASTC HDR 6x6 Intermediate
+images are supercompressed, the DFD must follow the rules described
 in the next <<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
-`KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the
+`KHR_DF_CHANNEL_UASTC_HDR_6x6_RGB` (= 0) for which the
 `KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
++
+The bitstream of UASTC HDR 6x6 data compressed with _UASTC HDR 6x6
+Intermediate_ is described in <<Basis UASTC HDR 6x6 Intermediate Bitstream Specification>>.
 
 [NOTE]
 ====
@@ -1252,22 +1294,6 @@ source image(s) alpha channel(s) that are all opaque (1.0) before
 submitting the data to a Basis encoder then the DFD must not
 have a sample with a channelType that indicates it is alpha.
 ====
-
-Basis GPU Photo::
-The GPU Photo format is indicated by `colorModel` `KHR_DF_MODEL_GPU_PHOTO`
-(= 168)  together with `vkFormat` `VK_FORMAT_UNDEFINED` (= 0). The
-format supports one compression ratio defined by a texel block size
-in the DFD of 6x6. Images in this format are always supercompressed
-with the Basis GPU Photo 6x6 scheme and must be inflated and
-transcoded to either standard ASTC HDR 6x6 format, if supported by
-the device, or to raw 16-bit floating-point values, before being
-uploaded to and sampled by a GPU. Because GPU Photo images are
-supercompressed, the DFD must follow the rules described in
-the next <<dfdSupercompressed,subsection>>.
-+
-This color model has a single channel with id
-`KHR_DF_CHANNEL_GPU_PHOTO_RGB` (= 0) for which the
-`KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
 
 [[dfdSupercompressed]]
 ===== DFD for Supercompressed Data
@@ -2414,6 +2440,11 @@ Bradner. IETF Network Working Group, March 1997.
   Collet, M. Kucherawy, Ed. Internet Engineering Task Force (IETF),
   October 2018.
 
+- [[[UASTCHDR44]]]
+  https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-4x4-Texture-Specification-v1.0[UASTC
+  HDR 4x4 Texture Specification v1.0].
+  Binomial Llc Wiki, Jan 2025.
+
 - [[[VULKAN]]] {url-vk-spec}[Vulkan^®^ 1.n.p - A Specification].
   The Khronos Group, February 2025.
 
@@ -2512,6 +2543,10 @@ include::formats.json[]
 include::appendices/basislz-gdata.adoc[]
 
 include::appendices/basislz-bitstream.adoc[]
+
+include::appendices/basisuah66i-gdata.adoc[]
+
+include::appendices/basisuah66i-bitstream.adoc[]
 
 include::appendices/vendor-metadata.adoc[]
 

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1162,9 +1162,9 @@ This color model has a single channel with id
 
 [NOTE]
 ====
-Because void-extent blocks in ASTC HDR can have negative values the Vulkan
-format names for ASTC HDR use `SFLOAT` although regular ASTC HDR blocks
-cannot have negative values. No UASTC HDR value can be < 0.
+Because void-extent blocks in ASTC HDR can have negative values the
+Vulkan format names for ASTC HDR use `SFLOAT` although regular ASTC
+HDR blocks cannot have negative values. No UASTC HDR value can be < 0.
 ====
 
 [[etc1s]]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1152,7 +1152,7 @@ two compression ratios defined by the texel block size in the DFD:
 subset so `vkFormat` must be set to whichever of
 `VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000) or
 `VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK` (= 1000066004) matches the texel
-block size. The DFD must be as described in Section ??? of <<KDF13>>.
+block size. The DFD must be as described in Section ??? of <<KDF14>>.
 Images in this format must be transcoded to BC6H or decoded to raw
 16-bit floating-point values before being uploaded to and sampled
 by a GPU that does not support ASTC HDR.  UASTC HDR images can be
@@ -2076,9 +2076,9 @@ These values must be finite.
 An application can restore the original 32-bit float value with
 [stem]
 +++++
-effective = sampled \times scale + offset
+\textit{effective} = \textit{sampled} \times \textit{scale} + \textit{offset}
 +++++
-where stem:[sampled] is the value retrieved from the texture after any
+where stem:[\textit{sampled}] is the value retrieved from the texture after any
 filtering.
 
 [TIP]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -16,13 +16,8 @@
 // names and indented blocks, overrides the unreadable equations.
 ////
 :stem: latexmath
-// Disabling toc and numbered attributes doesn't work with a2x.
-// Use the xsltproc options instead.
-:toc!:
-// a2x: --xsltproc-opts "--stringparam generate.toc nop"
+:toc: left
 :numbered:
-// a2x: --xsltproc-opts "--stringparam chapter.autolabel 0"
-// a2x: --xsltproc-opts "--stringparam section.autolabel 0"
 //:max-width: 50em
 :data-uri:
 :icons: font

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1147,7 +1147,7 @@ The Universal ASTC HDR image format (UASTC HDR) is indicated by
 as described in Section ??? of <<KDF13>>. Images in this format are
 a strict RGB-only ASTC HDR subset that must be transcoded to BC6H
 or decoded to raw 16-bit floating-point values before being uploaded
-to and sampled by a GPU that does not support ASTC. UASTC HDR
+to and sampled by a GPU that does not support ASTC HDR. UASTC HDR
 images can be supercompressed with Zstandard (`supercompressionScheme`
 = 2). If supercompression is used, the DFD's `bytesPlane[0-7]`
 must be set to 0 as described in the next subsection.

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1156,8 +1156,8 @@ Images in this format must be transcoded to BC6H or decoded to raw
 16-bit floating-point values before being uploaded to and sampled
 by a GPU that does not support ASTC HDR.  UASTC HDR images can be
 supercompressed with any scheme except BasisLZ (`supercompressionScheme`
-= 1). If supercompression is used, the DFD's `bytesPlane[0-7]` must
-be set to 0 as described in the next subsection.
+= 1). If supercompression is used, the DFD must follow the rules
+described in the next subsection.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1104,7 +1104,7 @@ can be supercompressed with Zstandard (`supercompressionScheme` =
 Optimization. If supercompression is used, the DFD must follow the
 rules described in the next subsection.
 +
-This color model provides channel Ids, e.g. `KHR_DF_CHANNEL_UASTC_RGB`
+This color model provides channel types, e.g. `KHR_DF_CHANNEL_UASTC_RGB`
 that must be used to indicate the effective number of components
 in the data.  Consumers use this information to help select a
 transcode target. The following ids are valid and must be used for
@@ -1132,7 +1132,7 @@ the type of data indicated.
 [TIP]
 ====
 _UASTC_RRRG cannot be transcoded to the RG channels of an ASTC or BC7
-texture. Applications using this channel id will have to use swizzles or
+texture. Applications using this channel type will have to use swizzles or
 have shaders that understand this channel layout.
 ====
 +
@@ -1152,8 +1152,9 @@ images can be supercompressed with Zstandard (`supercompressionScheme`
 = 2). If supercompression is used, the DFD's `bytesPlane[0-7]`
 must be set to 0 as described in the next subsection.
 +
-This color model provides a single channel id `KHR_DF_CHANNEL_UASTC_HDR_RGB`
-(= 0).
+This color model provides a single channel with type
+`KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the
+`KHR_DF_SAMPLE_DATATYPE_FLOAT` flag (= 0x80) must be set.
 
 [[etc1s]]
 Basis Universal ETC1S Format::
@@ -1183,7 +1184,7 @@ For better compression results, non-RGB slices may have the same value
 replicated in all 3 slice components.
 +
 Whether there are 1 or 2 slices depends on the pre-deflation components
-as detailed in the following table of valid channel id combinations.
+as detailed in the following table of valid channel type combinations.
 +
 [width=100%,align=center,cols="<65,<35",options=header]
 |===

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -539,7 +539,7 @@ If `faceCount` is equal to 6, `pixelHeight` must be equal to
 `pixelWidth`, and `pixelDepth` must be 0.
 
 `pixelHeight` must not be 0 for block-compressed formats, including
-BasisLZ/ETC1S and UASTC.
+BasisLZ/ETC1S, UASTC and UASTC HDR.
 
 `pixelDepth` must not be 0 for block-compressed formats that have
 block depth greater than 1.
@@ -971,7 +971,7 @@ _dfDescriptorBlock_.
   `KHR_DF_MODEL_YUVSDA` or the matching block compressed color model
   listed in <<KDF14>> {url-df-spec}#CompressedFormatModels[Section
   5.6] or its successors, currently `KHR_DF_MODEL_BC1A` to
-  `KHR_DF_MODEL_UASTC`.  `KHR_DF_MODEL_YUVSDA` should be used for
+  `KHR_DF_MODEL_UASTC_HDR`.  `KHR_DF_MODEL_YUVSDA` should be used for
   all non-prohibited `+*_422_*+` formats.
 * If <<_vkformat,`vkFormat`>> is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
@@ -1139,6 +1139,21 @@ have shaders that understand this channel layout.
 The bitstream of the UASTC data is described in Chapter 25
 {url-df-spec}#UASTC[_UASTC Compressed Texture Image Format_] of
 <<KDF14>>.
+
+Basis Universal UASTC HDR Format::
+The Universal ASTC HDR image format (UASTC HDR) is indicated by
+`colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167) together with `vkFormat`
+`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). The DFD must be
+as described in Section ??? of <<KDF13>>. Images in this format are
+a strict RGB-only ASTC subset that must be transcoded to BC6h before
+being uploaded to and sampled by a GPU that does not support ASTC.
+UASTC HDR images can be supercompressed with Zstandard
+(`supercompressionScheme` = 2).  If supercompression is used, the
+DFD's `bytesPlane[0-7]` must be set to 0 as described in the next
+subsection.
++
+This color model provides a single channel id `KHR_DF_CHANNEL_UASTC_HDR_RGB`
+(= 0, the same value as `KHR_DF_CHANNEL_ASTC_DATA`).
 
 [[etc1s]]
 Basis Universal ETC1S Format::

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -18,7 +18,6 @@
 :stem: latexmath
 :toc: left
 :numbered:
-//:max-width: 50em
 :data-uri:
 :icons: font
 :source-highlighter: prettify

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2672,6 +2672,7 @@ include::appendices/vendor-metadata.adoc[]
                                       in example KTX v2 file.
                                     - Specify how to carry the new
                                       Binomial HDR formats.
+                                    - Add table of contents.
 |===
 
 [discrete]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2176,6 +2176,32 @@ Metadata must be applied before swizzling and must be applied only to
 existing components. E.g, if blue and alpha are missing they must remain
 as 0.0 and 1.0.
 
+=== KTXxuastcBc7Transcodable
+Most 4x4, 6x6 and 8x6 XUASTC LDR blocks can be simply transcoded direct
+to BC7. Exclusive use of transcodable blocks can be signalled by using
+the key
+
+-   `KTXxuastcBc7Transcodable`
+
+The key has no value. It's presence signals transcodability.
+
+=== KTXxuastcDeblockFilter
+When XUASTC images are re-encoded to another format, an adaptive
+deblocking filter can be applied to reduce artifacts. This is done by
+default for block sizes > 8x6. Adaptive deblocking can be requested for
+other block sizes or disabled by using the key
+
+-   `KTXxuastcDeblockFilter`
+
+The value is a one-byte NUL-terminated string formatted as (<<REGEXP>>):
+
+[no-bullet]
+-   `/^[dns]{1}$/`
+
+where 'n' means do not apply a filter, 'd' means apply the default
+filter, and 's' mean apply the strong filter.
+
+
 == An example KTX version 2 file:
 
 [source,c]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2065,12 +2065,13 @@ KTX file writers may indicate the mapping by using the key
 - `KTXmapRange`
 
 The value is 8 bytes representing two IEEE 754 single-precision
-finite floating-point values:
+floating-point values:
 [source,c]
 ----
 Float32 scale
 Float32 offset
 ----
+These values must be finite.
 
 An application can restore the original 32-bit float value with
 [stem]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -535,7 +535,8 @@ If `faceCount` is equal to 6, `pixelHeight` must be equal to
 `pixelWidth`, and `pixelDepth` must be 0.
 
 `pixelHeight` must not be 0 for block-compressed formats, including
-BasisLZ/ETC1S, UASTC, UASTC HDR 4x4 and UASTC HDR 6x6 Intermediate.
+BasisLZ/ETC1S, UASTC LDR, UASTC HDR 4x4, UASTC HDR 6x6 Intermediate
+and XUASTC LDR.
 
 `pixelDepth` must not be 0 for block-compressed formats that have
 block depth greater than 1.
@@ -629,8 +630,9 @@ supercompression.
 | 1                    | BasisLZ         | <<etc1s_slice,ETC1S Slice Decoding>>  | <<basislz_gd,BasisLZ Global Data>>
 | 2                    | Zstandard       | <<RFC8478>>       | n/a
 | 3                    | ZLIB            | <<RFC1950>>       | n/a
-| 4                    | Basis UASTC 6x6 Intermediate | <<basisuah66i_bitstream,Basis UASTC HDR 6x6 Intermediate Bitstream Specification>> | <<basisuah66i_gd, Basis UASTC HDR 6x6 Intermediate Global Data>>
-| 5･･･0xffff           | Reserved^1^     |                   |
+| 4                    | Basis UASTC HDR 6x6 Intermediate | <<basisuah66i_bitstream,Basis UASTC HDR 6x6 Intermediate Bitstream Specification>> | <<basisuah66i_gd, Basis UASTC HDR 6x6 Intermediate Global Data>>
+| 5                    | Basis XUASTC LDR | <<basisxual_bitstream,Basis XUASTC LDR Bitstream Specification>> | <<basisxual_gd, Basis XUASTC LDR Global Data>>
+| 6･･･0xffff           | Reserved^1^     |                   |
 | 0x10000･･･0x1ffff    | Reserved^2^     |                   |
 | 0x20000･･･0xffffffff | Reserved^3^     |                   |
 |===
@@ -790,6 +792,21 @@ transcode target format is selected.
 * UASTC slice locations within a mip level are defined exclusively
   by the corresponding `ImageDesc` structures from the
   <<basisuah66i_global_data_structure>>. The same slice data may be
+  used by multiple `ImageDesc` structures within the mip level.
+* <<_vkformat,`vkFormat`>> must be `VK_FORMAT_UNDEFINED` (0x00).
+  The <<_data_format_descriptor,_Data Format Descriptor_>> must
+  retain the pre-deflation color space information.
+  See <<DFD for Supercompressed Data>>.
+* `<<_levelsp_uncompressedbytelength,levels[p].uncompressedByteLength>>`
+  must be 0.
+
+[#basisxual_scheme]
+===== Basis XUASTC LDR
+* <<Basis XUASTC LDR Bitstream Specification>>
+  describes the bitstream for a single image (slice).
+* XUASTC slice locations within a mip level are defined exclusively
+  by the corresponding `ImageDesc` structures from the
+  <<basisxual_global_data_structure>>. The same slice data may be
   used by multiple `ImageDesc` structures within the mip level.
 * <<_vkformat,`vkFormat`>> must be `VK_FORMAT_UNDEFINED` (0x00).
   The <<_data_format_descriptor,_Data Format Descriptor_>> must
@@ -985,7 +1002,7 @@ _dfDescriptorBlock_.
   `KHR_DF_MODEL_YUVSDA` or the matching block compressed color model
   listed in <<KDF14>> {url-df-spec}#CompressedFormatModels[Section
   5.6] or its successors, currently `KHR_DF_MODEL_BC1A` to
-  `KHR_DF_MODEL_UASTC_6x6_HDR`.  `KHR_DF_MODEL_YUVSDA` should be
+  `KHR_DF_MODEL_XUASTC_LDR`.  `KHR_DF_MODEL_YUVSDA` should be
   used for all non-prohibited `+*_422_*+` formats.
 * If <<_vkformat,`vkFormat`>> is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
@@ -1179,7 +1196,8 @@ This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_4x4_RGB` (= 0) for which the
 `KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
 +
-The bitstream of the UASTC HDR 4x4 data is described in <<UASTCHDR44>>.
+The ASTC HDR 4x4 subset that is UASTC HDR 4x4 data is described in <<UASTCHDR44>>.
+TODO: Update this link when KDFS is published.
 
 Basis Universal UASTC HDR 6x6 Format::
 The Universal ASTC HDR 6x6 image format (UASTC HDR 6x6) is a custom
@@ -1214,6 +1232,27 @@ Because void-extent blocks in ASTC HDR can have negative values the
 Vulkan format names for ASTC HDR use `SFLOAT` although regular ASTC
 HDR blocks cannot have negative values. No UASTC HDR value can be < 0.
 ====
+
+Basis Universal XUASTC LDR Format::
+The Universal XUASTC LDR image format (XUASTC LDR) is a custom
+format based off ASTC that underlies the <<basisxual_scheme,Basis
+XUASTC LDR>> supercompression scheme (`supercompressionScheme` =
+5).  `vkFormat` must be set to `VK_FORMAT_UNDEFINED` (= 0).  The
+DFD must be as described in Section 5.Y.ZZ
+{url-df-spec}#KHR_DF_MODEL_XUASTC_LDR[_KHR_DF_MODEL_XUASTC_LDR_] of <<KDF14>>
+with `colorModel` `KHR_DF_MODEL_XUASTC_LDR` (= 169).
+Images in this format are always supercompressed with the
+<<basisxual_scheme,Basis XUASTC LDR>> scheme and must be inflated
+and transcoded to a GPU-supported block-compressed format like
+`VK_FORMAT_ASTC_*_{SRGB,UNORM}_BLOCK` or `VK_FORMAT_BC7_{SRGB,UNORM}_BLOCK`
+or decoded to a GPU-supported uncompressed format before being
+uploaded to and sampled by a GPU.  Because XUASTC LDR images are
+supercompressed, the DFD must follow the rules described in the
+next <<dfdSupercompressed,subsection>>.  + This color model has a
+single channel with id `KHR_DF_CHANNEL_XUASTC_LDR_RGBA` (= 0).
++
+The bitstream of XUASTC LDR data compressed with _XUASTC LDR
+Intermediate_ is described in <<Basis XUASTC LDR Bitstream Specification>>.
 
 [[etc1s]]
 Basis Universal ETC1S Format::
@@ -1284,7 +1323,7 @@ single operation, this bitstream is not visible to applications.
 
 [IMPORTANT]
 ====
-The DFD for UASTC and ETC1S must reflect the components provided
+The DFD for UASTC LDR and ETC1S must reflect the components provided
 as input to the Basis encoders not those of the source image.
 Therefore, for example, if the software checks for and removes from
 source image(s) alpha channel(s) that are all opaque (1.0) before
@@ -2026,7 +2065,7 @@ If `KTXwriterScParams` is present, `KTXwriter` must also be present.
 In general only the most recent writer and most recently used options
 should be identified unless the writer is building on operations
 done previously. For example if a writer is adding Zstd supercompression
-to a file it previously encoded in UASTC, it should append the
+to a file it previously encoded in UASTC LDR, it should append the
 additional options to those previously used.
 
 === KTXastcDecodeMode
@@ -2459,9 +2498,19 @@ Bradner. IETF Network Working Group, March 1997.
   October 2018.
 
 - [[[UASTCHDR44]]]
-  https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-4x4-Texture-Specification-v1.0[UASTC
-  HDR 4x4 Texture Specification v1.0].
-  Binomial Llc Wiki, Jan 2025.
+  https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-4x4-Texture-Specification#uastc-hdr-4x4-texture-specification-v11[UASTC
+  HDR 4x4 Texture Specification v1.1].
+  Binomial Llc Wiki, Mar 2026.
+
+- [[[UASTCHDR66I]]]
+  https://github.com/BinomialLLC/basis_universal/wiki/UASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)#uastc-hdr-6x6i-intermediate-specification-v12[UASTC
+  HDR 6x6i (Intermediate) Texture Specification v1.2].
+  Binomial Llc Wiki, Mar 2026.
+
+- [[[XUASTCLDR]]]
+  https://github.com/BinomialLLC/basis_universal/wiki/XUASTC-LDR-Specification-v1.0#xuastc-ldr-specification[XUASTC
+  LDR Texture Specification v1.0].
+  Binomial Llc Wiki, Apr 2026.
 
 - [[[VULKAN]]] {url-vk-spec}[Vulkan^®^ 1.n.p - A Specification].
   The Khronos Group, February 2025.
@@ -2565,6 +2614,10 @@ include::appendices/basislz-bitstream.adoc[]
 include::appendices/basisuah66i-gdata.adoc[]
 
 include::appendices/basisuah66i-bitstream.adoc[]
+
+include::appendices/basisxual-gdata.adoc[]
+
+include::appendices/basisxual-bitstream.adoc[]
 
 include::appendices/vendor-metadata.adoc[]
 
@@ -2694,7 +2747,7 @@ include::appendices/vendor-metadata.adoc[]
                                     - Fix incorrect offsets, sizes and comments
                                       in example KTX v2 file.
                                     - Specify how to carry the new
-                                      Binomial HDR formats.
+                                      Binomial UASTC HDR and XUASTC formats.
                                     - Add table of contents.
 |===
 

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2189,15 +2189,15 @@ must not be set if the content includes other block dimensions. Such
 blocks must be re-encoded to BC7 preferably by bounded-time O(1) analytical
 encoding.
 
-This metadata entry may only be used with:
+This metadata entry may only be used if all the following are true:
 
-* `vkFormat == VK_FORMAT_UNDEFINED`
+* `vkFormat == VK_FORMAT_UNDEFINED` (0),
 
-* `supercompressionScheme == 5`, Basis XUASTC LDR
+* `supercompressionScheme == 5`, Basis XUASTC LDR,
 
-It must not be used with 
+* the DFD's `colorModel == KHR_DF_MODEL_XUASTC_LDR` (169),
 
-* `KTXxuastcDeblockFilter` metadata.
+* the file does not contain `KTXxuastcDeblockFilter`.
 
 If `KTXxuastcBc7Transcodable` appears in a KTX file violating these
 constraints, the file is invalid.
@@ -2220,15 +2220,15 @@ The value is a one-byte NUL-terminated string formatted as (<<REGEXP>>):
 where 'd' means disable filtering, 'n' means apply the normal
 filter, and 's' mean apply the strong filter.
 
-This metadata entry may only be used with:
+This metadata entry may only be used if all the following are true:
 
-* `vkFormat == VK_FORMAT_UNDEFINED`
+* `vkFormat == VK_FORMAT_UNDEFINED` (0),
 
-* `supercompressionScheme == 5`, Basis XUASTC LDR
+* `supercompressionScheme == 5`, Basis XUASTC LDR,
 
-It must not be used with 
+* the DFD's `colorModel == KHR_DF_MODEL_XUASTC_LDR` (169),
 
-* `KTXxuastcBc7Transcodable` metadata.
+* the file does not contain `KTXxuastcBc7Transcodable` metadata.
 
 If `KTXxuastcDeblockFilter` appears in a KTX file violating these
 constraints, the file is invalid.
@@ -2236,8 +2236,8 @@ constraints, the file is invalid.
 [NOTE]
 ====
 Some implementations may provide deblocking shaders for application
-which puts deblocking in the control of the application. They should
-use this metadata as a guide.
+which puts deblocking in the control of the application. Applications
+should use this metadata as a guide.
 ====
 
 

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1145,7 +1145,8 @@ The bitstream of the UASTC data is described in Chapter 25
 Basis Universal UASTC HDR Format::
 The Universal ASTC HDR image format (UASTC HDR) is indicated by
 `colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167) together with `vkFormat`
-`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). The DFD must be
+`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000) or
+`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK` (= 1000066004). The DFD must be
 as described in Section ??? of <<KDF13>>. Images in this format are
 a strict RGB-only ASTC HDR subset that must be transcoded to BC6H
 or decoded to raw 16-bit floating-point values before being uploaded
@@ -1157,12 +1158,13 @@ subsection.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the
-`KHR_DF_SAMPLE_DATATYPE_FLOAT` flag (= 0x80) must be set.
+`KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
 
 [NOTE]
 ====
-Although the Vulkan format names for ASTC HDR use `SFLOAT`, ASTC HDR and
-therefore UASTC HDR values cannot be < 0.
+Because void-extent blocks in ASTC HDR can have negative values the Vulkan
+format names for ASTC HDR use `SFLOAT` although regular ASTC HDR blocks
+cannot have negative values. No UASTC HDR value can be < 0.
 ====
 
 [[etc1s]]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1104,11 +1104,11 @@ can be supercompressed with Zstandard (`supercompressionScheme` =
 Optimization. If supercompression is used, the DFD must follow the
 rules described in the next subsection.
 +
-This color model provides channel types, e.g. `KHR_DF_CHANNEL_UASTC_RGB`
-that must be used to indicate the effective number of components
-in the data.  Consumers use this information to help select a
-transcode target. The following ids are valid and must be used for
-the type of data indicated.
+This color model has a single channel with several possible ids,
+e.g. `KHR_DF_CHANNEL_UASTC_RGB`, that are used to indicate the
+effective number of components in the data.  Consumers use this
+information to help select a transcode target. The following ids
+are valid and must be used for the type of data indicated.
 +
 [width=100%,align=center,cols="<30,^10,<60",options=header]
 |===
@@ -1132,7 +1132,7 @@ the type of data indicated.
 [TIP]
 ====
 _UASTC_RRRG cannot be transcoded to the RG channels of an ASTC or BC7
-texture. Applications using this channel type will have to use swizzles or
+texture. Applications using this channel id will have to use swizzles or
 have shaders that understand this channel layout.
 ====
 +
@@ -1152,7 +1152,7 @@ images can be supercompressed with Zstandard (`supercompressionScheme`
 = 2). If supercompression is used, the DFD's `bytesPlane[0-7]`
 must be set to 0 as described in the next subsection.
 +
-This color model provides a single channel with type
+This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the
 `KHR_DF_SAMPLE_DATATYPE_FLOAT` flag (= 0x80) must be set.
 
@@ -1164,8 +1164,9 @@ DFD must be as described in Section 5.6.11
 {url-df-spec}#KHR_DF_MODEL_ETC1S[_KHR_DF_MODEL_ETC1S_] of
 <<KDF14>>. Because ETC1S does not support an alpha component, Basis
 Universal uses 2 _slices_, (_planes_ in DFD-speak) to represent
-RGBA images.  This color model provides the following channel ids
-that must be used to indicate the use of a slice.
+RGBA images. In this color model each slice has a single channel
+with the following possible channel ids that must be used to indicate
+the use of a slice.
 +
 [width=100%,align=center,cols="<30,^10,<60",options=header]
 |===
@@ -1184,7 +1185,7 @@ For better compression results, non-RGB slices may have the same value
 replicated in all 3 slice components.
 +
 Whether there are 1 or 2 slices depends on the pre-deflation components
-as detailed in the following table of valid channel type combinations.
+as detailed in the following table of valid channel id combinations.
 +
 [width=100%,align=center,cols="<65,<35",options=header]
 |===

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2035,6 +2035,37 @@ seconds is stem:[\texttt{duration} / \texttt{timescale}].
 This metadata entry must not be used together with
 <<KTXcubemapIncomplete,`KTXcubemapIncomplete`>>.
 
+=== KTXmapRange
+When data is input from a source with 32-bit floating point data,
+such as a .exr file, and compressed to an HDR block format, such
+as ASTC HDR, BC6H or UASTC HDR, the values in the source may be
+mapped to the more limited range of the block-compressed format.
+KTX file writers may indicate the mapping by using the key
+
+- `KTXmapRange`
+
+The value is 8 bytes representing 2 Float32 values:
+[source,c]
+----
+Float32 scale
+Float32 offset
+----
+
+A shader can restore the original 32-bit float value with
+[stem]
++++++
+effective = sampled \times scale + offset
++++++
+
+[IMPORTANT]
+====
+It's important to multiply first so that decoders can use a single
+fused multiply-add instruction to apply the scale and the offset
+at once
+====
+
+This metadata entry may be used with any floating point format.
+
 == An example KTX version 2 file:
 
 [source,c]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -539,7 +539,7 @@ If `faceCount` is equal to 6, `pixelHeight` must be equal to
 `pixelWidth`, and `pixelDepth` must be 0.
 
 `pixelHeight` must not be 0 for block-compressed formats, including
-BasisLZ/ETC1S, UASTC, UASTC HDR and GPU Photo
+BasisLZ/ETC1S, UASTC, UASTC HDR and GPU Photo.
 
 `pixelDepth` must not be 0 for block-compressed formats that have
 block depth greater than 1.
@@ -1103,9 +1103,10 @@ The Universal ASTC image format (UASTC) is indicated by `colorModel`
 block-compressed format or decoded to a GPU-supported uncompressed
 format before being uploaded to and sampled by a GPU. UASTC images
 can be supercompressed with any scheme except BasisLZ
-(`supercompressionScheme` = 1). If supercompression is used, the
-DFD must follow the rules described in the next subsection.
-subsection.
+(`supercompressionScheme` = 1) and Basis GPU Photo 6x6
+(`supercompressionScheme` = 4). If supercompression is used, the
+DFD must follow the rules described in the next
+<<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with several possible ids,
 e.g. `KHR_DF_CHANNEL_UASTC_RGB`, that are used to indicate the
@@ -1156,8 +1157,9 @@ Images in this format must be transcoded to BC6H or decoded to raw
 16-bit floating-point values before being uploaded to and sampled
 by a GPU that does not support ASTC HDR.  UASTC HDR images can be
 supercompressed with any scheme except BasisLZ (`supercompressionScheme`
-= 1). If supercompression is used, the DFD must follow the rules
-described in the next subsection.
+= 1) and Basis GPU Photo 6x6 (`supercompressionScheme` = 4). If
+supercompression is used, the DFD must follow the rules described
+in the next <<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the
@@ -1225,8 +1227,8 @@ for ETC1S streams such as BasisLZ must be used.  Images must be
 inflated and transcoded to a GPU-supported block-compressed format
 or decoded to a GPU-supported uncompressed format before being
 uploaded to and sampled by a GPU. Because ETC1S images are
-supercompressed, the DFD must follow the rules described in the
-next subsection.
+supercompressed, the DFD must follow the rules described in
+the next <<dfdSupercompressed,subsection>>.
 
 TIP: Whether the image has 1 or 2 slices
 can be determined from the DFD's sample count.
@@ -1255,12 +1257,15 @@ in the DFD of 6x6. Images in this format are always supercompressed
 with the Basis GPU Photo 6x6 scheme and must be inflated and
 transcoded to either standard ASTC HDR 6x6 format, if supported by
 the device, or to raw 16-bit floating-point values, before being
-uploaded to and sampled by a GPU.
+uploaded to and sampled by a GPU. Because GPU Photo images are
+supercompressed, the DFD must follow the rules described in
+the next <<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_GPU_PHOTO_RGB` (= 0) for which the
 `KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
 
+[[dfdSupercompressed]]
 ===== DFD for Supercompressed Data
 When `<<_supercompressionscheme,supercompressionScheme>>` is not 0
 the _dfDescriptorBlock_ must preserve the `colorModel`, `transferFunction`,

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1144,17 +1144,19 @@ The bitstream of the UASTC data is described in Chapter 25
 
 Basis Universal UASTC HDR Format::
 The Universal ASTC HDR image format (UASTC HDR) is indicated by
-`colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167) together with `vkFormat`
+`colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167). This format supports
+two compression ratios defined by the texel block size in the DFD:
+4x4 and 6x6. Images in this format are a strict RGB-only ASTC HDR
+subset so `vkFormat` must be set to whichever of
 `VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000) or
-`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK` (= 1000066004). The DFD must be
-as described in Section ??? of <<KDF13>>. Images in this format are
-a strict RGB-only ASTC HDR subset that must be transcoded to BC6H
-or decoded to raw 16-bit floating-point values before being uploaded
-to and sampled by a GPU that does not support ASTC HDR. UASTC HDR
-images can be supercompressed with any scheme except BasisLZ
-(`supercompressionScheme` = 1). If supercompression is used, the
-DFD's `bytesPlane[0-7]` must be set to 0 as described in the next
-subsection.
+`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK` (= 1000066004) matches the texel
+block size. The DFD must be as described in Section ??? of <<KDF13>>.
+Images in this format must be transcoded to BC6H or decoded to raw
+16-bit floating-point values before being uploaded to and sampled
+by a GPU that does not support ASTC HDR.  UASTC HDR images can be
+supercompressed with any scheme except BasisLZ (`supercompressionScheme`
+= 1). If supercompression is used, the DFD's `bytesPlane[0-7]` must
+be set to 0 as described in the next subsection.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -96,6 +96,8 @@ Document Revision 3 approved by the 3D Formats WG Feb 14th, 2024.
 
 Document Revision 4 approved by the 3D Formats WG Feb 19th, 2025.
 
+Document Revision 5 in drafting.
+
 == Introduction
 
 This document describes the KTX^™️^ file format version 2.0, hereafter
@@ -2636,6 +2638,8 @@ include::appendices/vendor-metadata.adoc[]
                                       can vary from format definition.
                                     - Fix incorrect offsets, sizes and comments
                                       in example KTX v2 file.
+                                    - Specify how to carry the new
+                                      Binomial HDR formats.
 |===
 
 [discrete]

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1145,15 +1145,15 @@ The Universal ASTC HDR image format (UASTC HDR) is indicated by
 `colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167) together with `vkFormat`
 `VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). The DFD must be
 as described in Section ??? of <<KDF13>>. Images in this format are
-a strict RGB-only ASTC subset that must be transcoded to BC6h before
-being uploaded to and sampled by a GPU that does not support ASTC.
-UASTC HDR images can be supercompressed with Zstandard
-(`supercompressionScheme` = 2).  If supercompression is used, the
-DFD's `bytesPlane[0-7]` must be set to 0 as described in the next
-subsection.
+a strict RGB-only ASTC HDR subset that must be transcoded to BC6H
+or decoded to raw 16-bit floating-point values before being uploaded
+to and sampled by a GPU that does not support ASTC.  UASTC HDR
+images can be supercompressed with Zstandard (`supercompressionScheme`
+= 2).  If supercompression is used, the DFD's `bytesPlane[0-7]`
+must be set to 0 as described in the next subsection.
 +
 This color model provides a single channel id `KHR_DF_CHANNEL_UASTC_HDR_RGB`
-(= 0, the same value as `KHR_DF_CHANNEL_ASTC_DATA`).
+(= 0).
 
 [[etc1s]]
 Basis Universal ETC1S Format::

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -667,7 +667,7 @@ supercompression, e.g, scheme 2, may be ineffective on the
 block-compressed data of GPU texture formats. Compressibility can
 be improved by specially conditioning the data for LZW compression
 such as with _Rate-distortion Optimization_ <<RDO>>. Such conditioning
-in an encoding detail which is transparent to the user of the
+is an encoding detail which is transparent to the user of the
 texture.
 
 BasisLZ internally uses a universal block-compressed
@@ -2065,7 +2065,7 @@ KTX file writers may indicate the mapping by using the key
 - `KTXmapRange`
 
 The value is 8 bytes representing two IEEE 754 single-precision
-floating-point values:
+finite floating-point values:
 [source,c]
 ----
 Float32 scale

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2044,7 +2044,7 @@ KTX file writers may indicate the mapping by using the key
 
 - `KTXmapRange`
 
-The value is 8 bytes representing 2 Float32 values:
+The value is 8 bytes representing 2 IEEE 754 Float32 values:
 [source,c]
 ----
 Float32 scale
@@ -2060,8 +2060,7 @@ effective = sampled \times scale + offset
 [IMPORTANT]
 ====
 It's important to multiply first so that decoders can use a single
-fused multiply-add instruction to apply the scale and the offset
-at once
+fused multiply-add instruction to apply the scale and the offset.
 ====
 
 This metadata entry may be used with any floating point format.

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -633,7 +633,8 @@ supercompression.
 | 1                    | BasisLZ         | <<etc1s_slice,ETC1S Slice Decoding>>  | <<basislz_gd,BasisLZ Global Data>>
 | 2                    | Zstandard       | <<RFC8478>>       | n/a
 | 3                    | ZLIB            | <<RFC1950>>       | n/a
-| 4･･･0xffff           | Reserved^1^     |                   |
+| 4                    | Basis GPU Photo 6x6 | https://github.com/BinomialLLC/basis_universal/wiki/ASTC-HDR-6x6-Intermediate-File-Format-(Basis-GPU-Photo-6x6)        | n/a
+| 5･･･0xffff           | Reserved^1^     |                   |
 | 0x10000･･･0x1ffff    | Reserved^2^     |                   |
 | 0x20000･･･0xffffffff | Reserved^3^     |                   |
 |===
@@ -1093,7 +1094,7 @@ Premultiplied Alpha::
   field if the images' RGB components have been multiplied by their
   alpha components, otherwise it must be 0.
 
-Basis Universal UASTC Format::
+Basis Universal ASTC Format::
 The Universal ASTC image format (UASTC) is indicated by `colorModel`
 `KHR_DF_MODEL_UASTC` (= 166) together with `vkFormat` `VK_FORMAT_UNDEFINED`
 (= 0). The DFD must be as described in Section 5.6.14
@@ -1142,7 +1143,7 @@ The bitstream of the UASTC data is described in Chapter 25
 {url-df-spec}#UASTC[_UASTC Compressed Texture Image Format_] of
 <<KDF14>>.
 
-Basis Universal UASTC HDR Format::
+Basis Universal ASTC HDR Format::
 The Universal ASTC HDR image format (UASTC HDR) is indicated by
 `colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167). This format supports
 two compression ratios defined by the texel block size in the DFD:
@@ -1245,6 +1246,19 @@ source image(s) alpha channel(s) that are all opaque (1.0) before
 submitting the data to a Basis encoder then the DFD must not
 have a sample with a channelType that indicates it is alpha.
 ====
+
+Basis GPU Photo 6x6::
+The GPU Photo 6x6 format is indicated by `colorModel`
+`KHR_DF_MODEL_GPU_PHOTO_6x6` (= 168)  together with `vkFormat`
+`VK_FORMAT_UNDEFINED` (= 0). Images in this format are always
+supercompressed with the Basis GPU Photo 6x6 scheme and must be
+inflated and transcoded to either standard ASTC HDR 6x6 format, if
+supported by the device, or to raw 16-bit floating-point values,
+before being uploaded to and sampled by a GPU.
++
+This color model has a single channel with id
+`KHR_DF_CHANNEL_GPU_PHOTO_6x6_RGB` (= 0) for which the
+`KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
 
 ===== DFD for Supercompressed Data
 When `<<_supercompressionscheme,supercompressionScheme>>` is not 0

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2117,7 +2117,23 @@ This formula allows decoders to use a single fused multiply-add
 instruction to apply the scale and the offset.
 ====
 
-This metadata entry may be used with any floating point format.
+This metadata entry may be used with:
+
+* any floating point format. In the case of a combined depth-stencil
+format, e.g. `D32_SFLOAT_S8_UINT` it must be applied only to the
+depth component.
+
+* any linear `*_UNORM` or `*_SNORM` format.
+
+It is incompatible with and must not be used with:
+
+* non-linear formats such as those with sRGB encoding,
+
+* true integer or boolean formats.
+
+Metadata must be applied before swizzling and must be applied only to
+existing components. E.g, if blue and alpha are missing they must remain
+as 0.0 and 1.0.
 
 == An example KTX version 2 file:
 

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1156,6 +1156,12 @@ This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the
 `KHR_DF_SAMPLE_DATATYPE_FLOAT` flag (= 0x80) must be set.
 
+[NOTE]
+====
+Although the Vulkan format names for ASTC HDR use `SFLOAT`, ASTC HDR and
+therefore UASTC HDR values cannot be < 0.
+====
+
 [[etc1s]]
 Basis Universal ETC1S Format::
 The ETC1S image format is indicated by `colorModel` `KHR_DF_MODEL_ETC1S`

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2130,6 +2130,9 @@ It is incompatible with and must not be used with:
 
 * true integer or boolean formats.
 
+If `KTXmapRange` appears in a KTX file containing these formats, the
+file is invalid.
+
 Metadata must be applied before swizzling and must be applied only to
 existing components. E.g, if blue and alpha are missing they must remain
 as 0.0 and 1.0.

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -539,7 +539,7 @@ If `faceCount` is equal to 6, `pixelHeight` must be equal to
 `pixelWidth`, and `pixelDepth` must be 0.
 
 `pixelHeight` must not be 0 for block-compressed formats, including
-BasisLZ/ETC1S, UASTC and UASTC HDR.
+BasisLZ/ETC1S, UASTC, UASTC HDR and GPU Photo
 
 `pixelDepth` must not be 0 for block-compressed formats that have
 block depth greater than 1.
@@ -974,7 +974,7 @@ _dfDescriptorBlock_.
   `KHR_DF_MODEL_YUVSDA` or the matching block compressed color model
   listed in <<KDF14>> {url-df-spec}#CompressedFormatModels[Section
   5.6] or its successors, currently `KHR_DF_MODEL_BC1A` to
-  `KHR_DF_MODEL_UASTC_HDR`.  `KHR_DF_MODEL_YUVSDA` should be used for
+  `KHR_DF_MODEL_GPU_PHOTO`.  `KHR_DF_MODEL_YUVSDA` should be used for
   all non-prohibited `+*_422_*+` formats.
 * If <<_vkformat,`vkFormat`>> is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
@@ -1247,17 +1247,18 @@ submitting the data to a Basis encoder then the DFD must not
 have a sample with a channelType that indicates it is alpha.
 ====
 
-Basis GPU Photo 6x6::
-The GPU Photo 6x6 format is indicated by `colorModel`
-`KHR_DF_MODEL_GPU_PHOTO_6x6` (= 168)  together with `vkFormat`
-`VK_FORMAT_UNDEFINED` (= 0). Images in this format are always
-supercompressed with the Basis GPU Photo 6x6 scheme and must be
-inflated and transcoded to either standard ASTC HDR 6x6 format, if
-supported by the device, or to raw 16-bit floating-point values,
-before being uploaded to and sampled by a GPU.
+Basis GPU Photo::
+The GPU Photo format is indicated by `colorModel` `KHR_DF_MODEL_GPU_PHOTO`
+(= 168)  together with `vkFormat` `VK_FORMAT_UNDEFINED` (= 0). The
+format supports one compression ratio defined by a texel block size
+in the DFD of 6x6. Images in this format are always supercompressed
+with the Basis GPU Photo 6x6 scheme and must be inflated and
+transcoded to either standard ASTC HDR 6x6 format, if supported by
+the device, or to raw 16-bit floating-point values, before being
+uploaded to and sampled by a GPU.
 +
 This color model has a single channel with id
-`KHR_DF_CHANNEL_GPU_PHOTO_6x6_RGB` (= 0) for which the
+`KHR_DF_CHANNEL_GPU_PHOTO_RGB` (= 0) for which the
 `KHR_DF_SAMPLE_DATATYPE_FLOAT` qualifier (= 0x80) must be set.
 
 ===== DFD for Supercompressed Data

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1147,9 +1147,9 @@ The Universal ASTC HDR image format (UASTC HDR) is indicated by
 as described in Section ??? of <<KDF13>>. Images in this format are
 a strict RGB-only ASTC HDR subset that must be transcoded to BC6H
 or decoded to raw 16-bit floating-point values before being uploaded
-to and sampled by a GPU that does not support ASTC.  UASTC HDR
+to and sampled by a GPU that does not support ASTC. UASTC HDR
 images can be supercompressed with Zstandard (`supercompressionScheme`
-= 2).  If supercompression is used, the DFD's `bytesPlane[0-7]`
+= 2). If supercompression is used, the DFD's `bytesPlane[0-7]`
 must be set to 0 as described in the next subsection.
 +
 This color model provides a single channel id `KHR_DF_CHANNEL_UASTC_HDR_RGB`

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -986,8 +986,8 @@ _dfDescriptorBlock_.
   `KHR_DF_MODEL_YUVSDA` or the matching block compressed color model
   listed in <<KDF14>> {url-df-spec}#CompressedFormatModels[Section
   5.6] or its successors, currently `KHR_DF_MODEL_BC1A` to
-  `KHR_DF_MODEL_GPU_PHOTO`.  `KHR_DF_MODEL_YUVSDA` should be used for
-  all non-prohibited `+*_422_*+` formats.
+  `KHR_DF_MODEL_UASTC_6x6_HDR`.  `KHR_DF_MODEL_YUVSDA` should be
+  used for all non-prohibited `+*_422_*+` formats.
 * If <<_vkformat,`vkFormat`>> is one of the `+*_SRGB{,_*}+` formats,
   `transferFunction` must be `KHR_DF_TRANSFER_SRGB`.
 * If <<_vkformat,`vkFormat`>> is not one of the `+*_SRGB{,_*}+` formats
@@ -1106,7 +1106,7 @@ Premultiplied Alpha::
   field if the images' RGB components have been multiplied by their
   alpha components, otherwise it must be 0.
 
-Basis Universal ASTC Format::
+Basis Universal UASTC Format::
 The Universal ASTC image format (UASTC) is indicated by `colorModel`
 `KHR_DF_MODEL_UASTC` (= 166) together with `vkFormat` `VK_FORMAT_UNDEFINED`
 (= 0). The DFD must be as described in Section 5.6.14
@@ -1164,14 +1164,16 @@ as described in Section 5.6.10
 {url-df-spec}#KHR_DF_MODEL_ASTC[_KHR_DF_MODEL_ASTC_] of <<KDF14>>
 but `colorModel` must be `KHR_DF_MODEL_UASTC_HDR_4x4` (= 167),
 `texelBlockDimension[01]` must be 3 and `sampleLower` must be 0.
-Images in this format must be transcoded to a format supported by
-the device before being uploaded to and sampled by a GPU that does
-not support ASTC HDR, e.g.  `VK_FORMAT_BC6H_UFLOAT_BLOCK`,
-`VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` or `VK_FORMAT_R16G16B16A16_SFLOAT`.
-UASTC HDR 4x4 images can be supercompressed with any scheme except
-BasisLZ (`supercompressionScheme` = 1) and Basis UASTC HDR 6x6
-Intermediate (`supercompressionScheme` = 4).  If supercompression
-is used, the DFD must follow the rules described in the next
+If the GPU does not support `VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK`,
+images in this format must be transcoded to a GPU-supported
+block-compressed format like `VK_FORMAT_BC6H_UFLOAT_BLOCK` or decoded
+to a GPU-supported uncompressed format like
+`VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` or `VK_FORMAT_R16G16B16A16_SFLOAT`
+before being uploaded to and sampled by a GPU. UASTC HDR 4x4 images
+can be supercompressed with any scheme except BasisLZ
+(`supercompressionScheme` = 1) and Basis UASTC HDR 6x6 Intermediate
+(`supercompressionScheme` = 4).  If supercompression is used, the
+DFD must follow the rules described in the next
 <<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
@@ -1191,12 +1193,13 @@ UASTC HDR 6x6 Intermediate>> supercompression scheme
 168), `texelBlockDimension[01]` must be 5 and `sampleLower` must
 be 0. Images in this format are RGB-only and are always supercompressed
 with the <<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>
-scheme and must be inflated and transcoded to a format supported
-by the device before being uploaded to and sampled by a GPU, e.g
-`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK`, `VK_FORMAT_BC6H_UFLOAT_BLOCK`,
-`VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` or `VK_FORMAT_R16G16B16A16_SFLOAT`.
-Because UASTC HDR 6x6 Intermediate images are supercompressed, the
-DFD must follow the rules described in the next
+scheme and must be inflated and transcoded to a GPU-supported
+block-compressed format like `VK_FORMAT_BC6H_UFLOAT_BLOCK` or
+`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK` or decoded to a GPU-supported
+uncompressed format like `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` or
+`VK_FORMAT_R16G16B16A16_SFLOAT` before being uploaded to and sampled
+by a GPU. Because UASTC HDR 6x6 Intermediate images are supercompressed,
+the DFD must follow the rules described in the next
 <<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
@@ -2081,11 +2084,13 @@ This metadata entry must not be used together with
 <<KTXcubemapIncomplete,`KTXcubemapIncomplete`>>.
 
 === KTXmapRange
-When the payload is a floating point format with a restricted range,
-such as ASTC HDR, RGB9E5 and FLOAT16, and data is input from a
-source with 32-bit floating point data, such as a .exr file,
-the values in the source may be mapped to the more limited range.
-KTX file writers may indicate the mapping by using the key
+When the payload is a floating point format with a reduced range,
+such as `ASTC_*\_SFLOAT_BLOCK`, `BC6H_[S,U]FLOAT_BLOCK`,
+`B10G11R11_UFLOAT_PACK32`, `E5B9G9R9_UFLOAT_PACK32` or
+`R16[G16[B16[A16]]]_SFLOAT` and data is input from a source with
+32-bit floating point data, such as a .exr file, the values in the
+source may be mapped to the more limited range. KTX file writers
+may indicate the mapping by using the key
 
 - `KTXmapRange`
 

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -656,6 +656,11 @@ uses global data. The format of the global data for a scheme
 is specified in the reference given in the _Global Data Format_
 column of <<supercompressionSchemes>>.
 
+Image data may be conditioned with Rate-distortion Optimization prior to
+supercompression to further reduce the final size. This is transparent
+to the user of the texture so KTX provides no indication that RDO has
+been used.
+
 When a supercompression scheme is used, the image data must be
 inflated from the scheme prior to GPU sampling.
 
@@ -1098,11 +1103,11 @@ The Universal ASTC image format (UASTC) is indicated by `colorModel`
 {url-df-spec}#KHR_DF_MODEL_UASTC[_KHR_DF_MODEL_UASTC_] of
 <<KDF14>>. Images in this format must be transcoded to a GPU-supported
 block-compressed format or decoded to a GPU-supported uncompressed
-format before being uploaded to and sampled by a GPU.  UASTC images
-can be supercompressed with Zstandard (`supercompressionScheme` =
-2) with or without first conditioning the data with Rate-distortion
-Optimization. If supercompression is used, the DFD must follow the
-rules described in the next subsection.
+format before being uploaded to and sampled by a GPU. UASTC images
+can be supercompressed with any scheme except BasisLZ
+(`supercompressionScheme` = 1). If supercompression is used, the
+DFD must follow the rules described in the next subsection.
+subsection.
 +
 This color model has a single channel with several possible ids,
 e.g. `KHR_DF_CHANNEL_UASTC_RGB`, that are used to indicate the
@@ -1148,9 +1153,10 @@ as described in Section ??? of <<KDF13>>. Images in this format are
 a strict RGB-only ASTC HDR subset that must be transcoded to BC6H
 or decoded to raw 16-bit floating-point values before being uploaded
 to and sampled by a GPU that does not support ASTC HDR. UASTC HDR
-images can be supercompressed with Zstandard (`supercompressionScheme`
-= 2). If supercompression is used, the DFD's `bytesPlane[0-7]`
-must be set to 0 as described in the next subsection.
+images can be supercompressed with any scheme except BasisLZ
+(`supercompressionScheme` = 1). If supercompression is used, the
+DFD's `bytesPlane[0-7]` must be set to 0 as described in the next
+subsection.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_RGB` (= 0) for which the

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -2036,31 +2036,34 @@ This metadata entry must not be used together with
 <<KTXcubemapIncomplete,`KTXcubemapIncomplete`>>.
 
 === KTXmapRange
-When data is input from a source with 32-bit floating point data,
-such as a .exr file, and compressed to an HDR block format, such
-as ASTC HDR, BC6H or UASTC HDR, the values in the source may be
-mapped to the more limited range of the block-compressed format.
+When the payload is a floating point format with a restricted range,
+such as ASTC HDR, RGB9E5 and FLOAT16, and data is input from a
+source with 32-bit floating point data, such as a .exr file,
+the values in the source may be mapped to the more limited range.
 KTX file writers may indicate the mapping by using the key
 
 - `KTXmapRange`
 
-The value is 8 bytes representing 2 IEEE 754 Float32 values:
+The value is 8 bytes representing two IEEE 754 single-precision
+floating-point values:
 [source,c]
 ----
 Float32 scale
 Float32 offset
 ----
 
-A shader can restore the original 32-bit float value with
+An application can restore the original 32-bit float value with
 [stem]
 +++++
 effective = sampled \times scale + offset
 +++++
+where stem:[sampled] is the value retrieved from the texture after any
+filtering.
 
-[IMPORTANT]
+[TIP]
 ====
-It's important to multiply first so that decoders can use a single
-fused multiply-add instruction to apply the scale and the offset.
+This formula allows decoders to use a single fused multiply-add
+instruction to apply the scale and the offset.
 ====
 
 This metadata entry may be used with any floating point format.

--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1162,16 +1162,17 @@ RGB-only subset of ASTC HDR 4x4. `vkFormat` must be set to
 `VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). The DFD must be
 as described in Section 5.6.10
 {url-df-spec}#KHR_DF_MODEL_ASTC[_KHR_DF_MODEL_ASTC_] of <<KDF14>>
-but `colorModel` must be `KHR_DF_MODEL_UASTC_HDR_4x4` (= 167) and
-`texelBlockDimension[01]` must be 4.  Images in this format must
-be transcoded to a format supported by the device before being
-uploaded to and sampled by a GPU that does not support ASTC HDR,
-e.g.  `VK_FORMAT_BC6H_UFLOAT_BLOCK`, `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`
-or `VK_FORMAT_R16G16B16A16_SFLOAT`.  UASTC HDR 4x4 images can be
-supercompressed with any scheme except BasisLZ (`supercompressionScheme`
-= 1) and Basis UASTC HDR 6x6 Intermediate (`supercompressionScheme`
-= 4).  If supercompression is used, the DFD must follow the rules
-described in the next <<dfdSupercompressed,subsection>>.
+but `colorModel` must be `KHR_DF_MODEL_UASTC_HDR_4x4` (= 167),
+`texelBlockDimension[01]` must be 3 and `sampleLower` must be 0.
+Images in this format must be transcoded to a format supported by
+the device before being uploaded to and sampled by a GPU that does
+not support ASTC HDR, e.g.  `VK_FORMAT_BC6H_UFLOAT_BLOCK`,
+`VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` or `VK_FORMAT_R16G16B16A16_SFLOAT`.
+UASTC HDR 4x4 images can be supercompressed with any scheme except
+BasisLZ (`supercompressionScheme` = 1) and Basis UASTC HDR 6x6
+Intermediate (`supercompressionScheme` = 4).  If supercompression
+is used, the DFD must follow the rules described in the next
+<<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_4x4_RGB` (= 0) for which the
@@ -1181,23 +1182,22 @@ The bitstream of the UASTC HDR 4x4 data is described in <<UASTCHDR44>>.
 
 Basis Universal UASTC HDR 6x6 Format::
 The Universal ASTC HDR 6x6 image format (UASTC HDR 6x6) is a custom
-format based off ASTC HDR 6x6 that underlies the
-<<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>
-supercompression scheme (`supercompressionScheme`
-= 4).  `vkFormat` must be set to `VK_FORMAT_UNDEFINED` (= 0).  The
-DFD must be as described in Section 5.6.10
-{url-df-spec}#KHR_DF_MODEL_ASTC[_KHR_DF_MODEL_ASTC_] of <<KDF14>>
-but `colorModel` must be `KHR_DF_MODEL_UASTC_6x6_HDR` (= 168) and
-`texelBlockDimension[01]` must be 6. Images in this format are
-RGB-only and are always supercompressed with the
-<<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>
-scheme and must be inflated and transcoded to a
-format supported by the device before being uploaded to and sampled
-by a GPU, e.g `VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK`,
-`VK_FORMAT_BC6H_UFLOAT_BLOCK`, `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`
-or `VK_FORMAT_R16G16B16A16_SFLOAT`.  Because UASTC HDR 6x6 Intermediate
-images are supercompressed, the DFD must follow the rules described
-in the next <<dfdSupercompressed,subsection>>.
+format based off ASTC HDR 6x6 that underlies the <<basisuah66_scheme,Basis
+UASTC HDR 6x6 Intermediate>> supercompression scheme
+(`supercompressionScheme` = 4).  `vkFormat` must be set to
+`VK_FORMAT_UNDEFINED` (= 0).  The DFD must be as described in Section
+5.6.10 {url-df-spec}#KHR_DF_MODEL_ASTC[_KHR_DF_MODEL_ASTC_] of
+<<KDF14>> but `colorModel` must be `KHR_DF_MODEL_UASTC_6x6_HDR` (=
+168), `texelBlockDimension[01]` must be 5 and `sampleLower` must
+be 0. Images in this format are RGB-only and are always supercompressed
+with the <<basisuah66_scheme,Basis UASTC HDR 6x6 Intermediate>>
+scheme and must be inflated and transcoded to a format supported
+by the device before being uploaded to and sampled by a GPU, e.g
+`VK_FORMAT_ASTC_6x6_SFLOAT_BLOCK`, `VK_FORMAT_BC6H_UFLOAT_BLOCK`,
+`VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` or `VK_FORMAT_R16G16B16A16_SFLOAT`.
+Because UASTC HDR 6x6 Intermediate images are supercompressed, the
+DFD must follow the rules described in the next
+<<dfdSupercompressed,subsection>>.
 +
 This color model has a single channel with id
 `KHR_DF_CHANNEL_UASTC_HDR_6x6_RGB` (= 0) for which the


### PR DESCRIPTION
Draft of language to add support for UASTC HDR. KDFS and all KDFS references need updating before this can be considered ready for merge.

Draft says to use `colorModel` `KHR_DF_MODEL_UASTC_HDR` (= 167) together with `vkFormat`
`VK_FORMAT_ASTC_4x4_SFLOAT_BLOCK` (= 1000066000). Any issues with that?