### PR TITLE
Remove requirement that bytesPlane be 0 for supercompressed.

### DIFF
--- a/ktxspec.adoc
+++ b/ktxspec.adoc
@@ -1033,8 +1033,7 @@ uncompressed format before being uploaded to and sampled by a GPU.
 UASTC images can be supercompressed with Zstandard
 (`supercompressionScheme` = 2) with or without first conditioning
 the data with Rate-distortion Optimization. If supercompression is
-used, the DFD's `bytesPlane[0-7]` must be set to 0 as described in
-the next subsection.
+used, the DFD must follow the rules described in the next subsection.
 +
 This color model provides channel Ids, e.g. `KHR_DF_CHANNEL_UASTC_RGB`
 that must be used to indicate the effective number of components
@@ -1123,8 +1122,8 @@ Images in this format are always supercompressed with BasisLZ and
 must be inflated and transcoded to a GPU-supported block-compressed
 format  or decoded to a GPU-supported uncompressed format before
 being uploaded to and sampled by a GPU. Because ETC1S images are
-supercompressed, the DFD's `bytesPlane[0-7]` must be set to 0 as
-described in the next subsection.
+supercompressed, the DFD must follow the rules described in the
+next subsection.
 
 TIP: Whether the image has 1 or 2 slices
 can be determined from the DFD's sample count.
@@ -1148,11 +1147,18 @@ have a sample with a channelType that indicates it is alpha.
 ===== DFD for Supercompressed Data
 When `<<_supercompressionscheme,supercompressionScheme>>` is not 0
 the _dfDescriptorBlock_ must preserve the `colorModel`, `transferFunction`,
-`colorPrimaries`, `flags` and `texelBlockDimension[0-3]` of the
-pre-deflation images along with each sample's `channelType`,
-`qualifiers`, `bitlength`, `bitOffset`, `sampleLower` and `sampleUpper`.
-`bytesPlane[0-7]` must be set to 0 to indicate an _unsized format_,
-as described in Section 5.19 _Unsized Formats_ of <<KDF13>>.
+`colorPrimaries`, `flags`, `texelBlockDimension[0-3]` and
+`bytesPlane[0-7]` of the pre-deflation images along with each
+sample's `channelType`, `qualifiers`, `bitlength`, `bitOffset`,
+`sampleLower`, and `sampleUpper`.
+
+[NOTE]
+====
+Previous document revisions required  `bytesPlane[0-7]` to be set to
+0 to indicate an _unsized format_ in accordance with Data Formats
+v1.3.1 and unpublished drafts of <<KDF13>>. For the foreseeable future
+software must be able to handle such KTX files.
+====
 
 [NOTE]
 ====
@@ -1177,7 +1183,7 @@ unsigned 8-bit components.
 8+^| *_flags:_* *++ALPHA_STRAIGHT++* 8+^| *_transferFunction:_* *++LINEAR++* 8+^| *_colorPrimaries:_* *++BT709++* 8+^| *_colorModel:_* *++ETC1S++*
 8+^| *_~texelBlockDimension3~_* 8+^| *_~texelBlockDimension2~_* 8+^| *_~texelBlockDimension1~_* 8+^| *_~texelBlockDimension0~_*
 8+^| 0 8+^| 0 8+^| 3 (= ``4'') 8+^| 3 (= ``4'')
-8+^| *_bytesPlane3:_* 0 8+^| *_bytesPlane2:_* 0 8+^| *_bytesPlane1:_* 0 8+^| *_bytesPlane0:_* 0
+8+^| *_bytesPlane3:_* 0 8+^| *_bytesPlane2:_* 0 8+^| *_bytesPlane1:_* 0 8+^| *_bytesPlane0:_* 2
 8+^| *_bytesPlane7:_* 0 8+^| *_bytesPlane6:_* 0 8+^| *_bytesPlane5:_* 0 8+^| *_bytesPlane4:_* 0
 ^| *_~F~_* ^| *_~S~_* ^| *_~E~_* ^| *_~L~_* 4+^| *_~channelType~_* 24+^|
 ~Red sample information~
@@ -1212,7 +1218,7 @@ before deflation, i.e. have 3 signed 8-bit components.
 *++LINEAR++* 8+^| *_colorPrimaries:_* *++BT709++* 8+^| *_colorModel:_* *++RGBSDA++*
 8+^| *_~texelBlockDimension3~_* 8+^| *_~texelBlockDimension2~_* 8+^| *_~texelBlockDimension1~_* 8+^| *_~texelBlockDimension0~_*
 8+^| 0 8+^| 0 8+^| 0 8+^| 0
-8+^| *_bytesPlane3:_* 0 8+^| *_bytesPlane2:_* 0 8+^| *_bytesPlane1:_* 0 8+^| *_bytesPlane0:_* 0
+8+^| *_bytesPlane3:_* 0 8+^| *_bytesPlane2:_* 0 8+^| *_bytesPlane1:_* 0 8+^| *_bytesPlane0:_* 3
 8+^| *_bytesPlane7:_* 0 8+^| *_bytesPlane6:_* 0 8+^| *_bytesPlane5:_* 0 8+^| *_bytesPlane4:_* 0
 ^| *_~F~_* ^| *_~S~_* ^| *_~E~_* ^| *_~L~_* 4+^| *_~channelType~_* 24+^| ~Red sample information~
 ^| 0 ^| 1 ^| 0 ^| 0 4+^| *++RED++* 8+^| *_bitLength:_* 7 16+^| *_bitOffset:_* 0
@@ -2452,6 +2458,9 @@ include::appendices/vendor-metadata.adoc[]
                                       the object coordinate systems
                                       commonly used with OpenGL and
                                       Vulkan.
+                                    - Remove requirement for bytesPlane
+                                      0 in DFDs of supercompressed
+                                      files.
 |===
 
 [discrete]


### PR DESCRIPTION
In accordance with upcoming KDF revision.