### PR TITLE
chore: Add AI-Assisted Contributions and fix CLA pre-disclosure [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,18 @@
 ## Contributing
 
 This project welcomes contributions and suggestions. All contributions require agreement to a Contributor License Agreement (CLA), confirming that you have the right to, and do, grant us the rights to use your contribution.
-The full text of the CLA is available at: https://gist.github.com/KhronosWebservices/f7df35f3fb11010843ac
+The full text of the CLA is available at: https://cla-assistant.io/KhronosGroup/KTX-Specification
+
+## AI-Assisted Contributions
+
+By submitting a Contribution to this repository, you additionally represent
+that, to the extent any of Your Contributions were developed with the
+assistance of artificial intelligence tools or AI-generated code, You have
+exercised sufficient review, judgment, and creative direction over such tools
+and resulting material to reasonably consider it Your original creation, and
+You are not aware of any third-party license, intellectual property claim, or
+other restriction arising from such use that is associated with any part of
+Your Contribution or use thereof.
 
 ## Khronos Member Companies
 


### PR DESCRIPTION
This PR adds a legal mandated AI contributions block of text to the CONTRIBUTING file. As well, the link pointing to the CLA has been updated to point to cla-assistant instead of directly to the Gist backing the CLA. 